### PR TITLE
Fix blueprint typo: "metrics-adapter[s]"

### DIFF
--- a/blueprints/metrics-adapter/index.js
+++ b/blueprints/metrics-adapter/index.js
@@ -2,7 +2,7 @@ module.exports = {
   description: 'Generates an ember-metrics adapter.',
 
   locals: function(options) {
-    var importStatement = "import BaseAdapter from 'ember-metrics/metrics-adapter/base';";
+    var importStatement = "import BaseAdapter from 'ember-metrics/metrics-adapters/base';";
     var baseClass = 'BaseAdapter';
     var toStringExtension = 'return ' + "'" + options.entity.name + "';";
     // Return custom template variables here.


### PR DESCRIPTION
Came across this little blueprint typo while working on some custom adapters.  
![screen shot 2015-08-17 at 5 34 39 pm](https://cloud.githubusercontent.com/assets/489896/9319803/7d38c6d2-4507-11e5-97b7-2781b1e343d4.png)

Normally I try to always add tests for PR's, but not sure if/how blueprint file-gen code is tested..

Thanks for a sweet library! Refactoring our spaghetti pre-`Ember.Service` analytics util right now :D