### PR TITLE
Adds identify method to GoogleAnalytics adapter.

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -34,6 +34,13 @@ export default BaseAdapter.extend({
     }
   },
 
+  identify(options = {}) {
+    const compactedOptions = compact(options);
+    const { distinctId } = compactedOptions;
+
+    window.ga('set', 'userId', distinctId);
+  },
+
   trackEvent(options = {}) {
     const compactedOptions = compact(options);
     const sendEvent = { hitType: 'event' };

--- a/tests/unit/metrics-adapters/google-analytics-test.js
+++ b/tests/unit/metrics-adapters/google-analytics-test.js
@@ -15,6 +15,17 @@ moduleFor('ember-metrics@metrics-adapter:google-analytics', 'google-analytics ad
   }
 });
 
+test('#identify calls ga with the right arguments', function(assert) {
+  var adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'ga', () => {
+    return true;
+  });
+  adapter.identify({
+    distinctId: 123
+  });
+  assert.ok(stub.calledWith('set', 'userId', 123), 'it sends the correct arguments');
+});
+
 test('#trackEvent returns the correct response shape', function(assert) {
   const adapter = this.subject({ config });
   sandbox.stub(window, 'ga');

--- a/tests/unit/metrics-adapters/google-analytics-test.js
+++ b/tests/unit/metrics-adapters/google-analytics-test.js
@@ -16,7 +16,7 @@ moduleFor('ember-metrics@metrics-adapter:google-analytics', 'google-analytics ad
 });
 
 test('#identify calls ga with the right arguments', function(assert) {
-  var adapter = this.subject({ config });
+  const adapter = this.subject({ config });
   const stub = sandbox.stub(window, 'ga', () => {
     return true;
   });

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -97,10 +97,10 @@ test('#invoke invokes the named method on activated adapters', function(assert) 
 
   assert.ok(GoogleAnalyticsSpy.calledOnce, 'it invokes the identify method on the adapter');
   assert.ok(GoogleAnalyticsSpy.calledWith(options), 'it invokes with the correct arguments');
+  assert.ok(GoogleAnalyticsStub.calledOnce, 'it invoked the GoogleAnalytics method');
   assert.ok(MixpanelSpy.calledOnce, 'it invokes the identify method on the adapter');
   assert.ok(MixpanelSpy.calledWith(options), 'it invokes with the correct arguments');
   assert.ok(MixpanelStub.calledOnce, 'it invoked the Mixpanel method');
-  assert.equal(GoogleAnalyticsStub.callCount, 0, 'it does not call methods that are not implemented by the adapter');
 });
 
 test('#invoke invokes the named method on a single activated adapter', function(assert) {


### PR DESCRIPTION
Hey, I noticed that GoogleAnalytics adapter was missing the identify method.
This is my suggestion to add that.