### PR TITLE
Enable options on google-analytics init

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -4,6 +4,7 @@ import objectTransforms from '../utils/object-transforms';
 import BaseAdapter from './base';
 
 const {
+  copy,
   assert,
   merge,
   get,
@@ -18,10 +19,14 @@ export default BaseAdapter.extend({
   },
 
   init() {
-    const config = get(this, 'config');
+    const config = copy(get(this, 'config'));
     const { id } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
+
+    delete config.id;
+
+    const hasOptions = Ember.isPresent(Object.keys(config));
 
     if (canUseDOM) {
       /* jshint ignore:start */
@@ -29,8 +34,13 @@ export default BaseAdapter.extend({
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      window.ga('create', id, 'auto');
       /* jshint ignore:end */
+      
+      if(hasOptions){
+        window.ga('create', id, config);
+      } else {
+        window.ga('create', id, 'auto');
+      }
     }
   },
 

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -4,6 +4,7 @@ import objectTransforms from '../utils/object-transforms';
 import BaseAdapter from './base';
 
 const {
+  isPresent,
   copy,
   assert,
   merge,
@@ -26,7 +27,7 @@ export default BaseAdapter.extend({
 
     delete config.id;
 
-    const hasOptions = Ember.isPresent(Object.keys(config));
+    const hasOptions = isPresent(Object.keys(config));
 
     if (canUseDOM) {
       /* jshint ignore:start */
@@ -36,7 +37,7 @@ export default BaseAdapter.extend({
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
       /* jshint ignore:end */
       
-      if(hasOptions){
+      if (hasOptions) {
         window.ga('create', id, config);
       } else {
         window.ga('create', id, 'auto');


### PR DESCRIPTION
It’s important for google analytics to be initialized with some options e.g. 'cookieDomain’ that is used to allow testing on localhost and can only be set on create.
This is my suggestion on how to add that.