### PR TITLE
enable users to specify the environments they what to track.

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -61,7 +61,7 @@ export default Service.extend({
   invoke(methodName, ...args) {
     const adaptersObj = get(this, '_adapters');
     const adapterNames = Object.keys(adaptersObj);
-    const environment = get(this, 'environment')
+    const environment = get(this, 'environment');
 
     const adapters = adapterNames.map((adapterName) => {
       return get(adaptersObj, adapterName);
@@ -71,16 +71,30 @@ export default Service.extend({
       let [ adapterName, options ] = args;
       const adapter = get(adaptersObj, adapterName);
 
-      if (environment in adapter.environments)
+      if (environment && adapter.environments){
+        if (environment in adapter.environments) {
+          adapter[methodName](options);
+        }
+        else {
+          Ember.Logger.info(`[ember-metrics] ${adapter.name} ${options}`);
+        }
+      }
+      else {
         adapter[methodName](options);
-      else
-        Ember.Logger.info(`[ember-metrics] ${adapter.name} ${options}`)
+      }
     } else {
       adapters.forEach((adapter) => {
-        if (environment in adapter.environments)
+        if (environment && adapter.environments){
+          if (environment in adapter.environments){
+            adapter[methodName](...args);
+          }
+          else {
+            Ember.Logger.info(`[ember-metrics] ${adapter.name} ${args}`);
+          }
+        }
+        else {
           adapter[methodName](...args);
-        else
-          Ember.Logger.info(`[ember-metrics] ${adapter.name} ${args}`)
+        }
       });
     }
   },

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -71,38 +71,33 @@ export default Service.extend({
       let [ adapterName, options ] = args;
       const adapter = get(adaptersObj, adapterName);
 
-
-
-      if (environment && adapter.environments){
-        if (this._adapterUsedForEnvironment(adapter, environment)) {
-          adapter[methodName](options);
-        }
-        else {
-          Ember.Logger.info(`[ember-metrics] ${adapter.name} ${options}`);
-        }
-      }
-      else {
+      if (this._adapterUsedForEnvironment(adapter, environment)) {
         adapter[methodName](options);
       }
-    } else {
+      else {
+        Ember.Logger.info(`[ember-metrics] ${adapter.name} ${options}`);
+      }
+    }
+    else {
       adapters.forEach((adapter) => {
-        if (environment && adapter.environments){
-          if (this._adapterUsedForEnvironment(adapter, environment)){
-            adapter[methodName](...args);
-          }
-          else {
-            Ember.Logger.info(`[ember-metrics] ${adapter.name} ${args}`);
-          }
+        if (this._adapterUsedForEnvironment(adapter, environment)){
+          adapter[methodName](...args);
         }
         else {
-          adapter[methodName](...args);
+          Ember.Logger.info(`[ember-metrics] ${adapter.name} ${args}`);
         }
       });
     }
   },
 
   _adapterUsedForEnvironment(adapter, environment){
-    return adapter.get('environments').contains(environment);
+    let environments = adapter.get('environments');
+    if(isNone(environments)){
+      return false;
+    }
+    else{
+      return environments.contains(environment);
+    }
   },
 
   _activateAdapter(adapterOption = {}) {

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -71,8 +71,10 @@ export default Service.extend({
       let [ adapterName, options ] = args;
       const adapter = get(adaptersObj, adapterName);
 
+
+
       if (environment && adapter.environments){
-        if (environment in adapter.environments) {
+        if (this._adapterUsedForEnvironment(adapter, environment)) {
           adapter[methodName](options);
         }
         else {
@@ -85,7 +87,7 @@ export default Service.extend({
     } else {
       adapters.forEach((adapter) => {
         if (environment && adapter.environments){
-          if (environment in adapter.environments){
+          if (this._adapterUsedForEnvironment(adapter, environment)){
             adapter[methodName](...args);
           }
           else {
@@ -97,6 +99,10 @@ export default Service.extend({
         }
       });
     }
+  },
+
+  _adapterUsedForEnvironment(adapter, environment){
+    return adapter.get('environments').contains(environment);
   },
 
   _activateAdapter(adapterOption = {}) {

--- a/app/initializers/metrics.js
+++ b/app/initializers/metrics.js
@@ -2,9 +2,12 @@ import config from '../config/environment';
 
 export function initialize(_container, application ) {
   const { metricsAdapters = {} } = config;
+  const { environment = 'development' } = config;
 
   application.register('config:metrics', metricsAdapters, { instantiate: false });
+  application.register('config:metrics-env', environment, { instantiate: false });
   application.inject('service:metrics', 'metricsAdapters', 'config:metrics');
+  application.inject('service:metrics', 'environment', 'config:metrics-env');
 }
 
 export default {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-metrics",
   "dependencies": {
-    "ember": "components/ember#release",
+    "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",

--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,5 @@
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "sinonjs": "~1.14.1"
-  },
-  "resolutions": {
-    "ember": "release"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-metrics",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "components/ember#release",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
@@ -12,5 +12,8 @@
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "sinonjs": "~1.14.1"
+  },
+  "resolutions": {
+    "ember": "release"
   }
 }


### PR DESCRIPTION
Specify in which environments you want tracking to be anabled by adding an array:
```
    metricsAdapters: [
      {
        name: 'GoogleAnalytics',
        config: {
          id: 'UA-54495053-2'
        },
        environments: ['production']
      },
      {
        name: 'Calq',
        config: {
          id: 'ca78eed5d34a041ab5cf164295cf2c25'
        },
        environments: ['production']
      },
    ]
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/poteto/ember-metrics/34)
<!-- Reviewable:end -->
