### PR TITLE
Introduce metrics.context

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Adapter names are PascalCased. Refer to the [list of supported adapters](#curren
 The `metricsAdapters` option in `ENV` accepts an array of objects containing settings for each analytics service you want to use in your app in the following format:
 
 ```js
-/** 
+/**
  * @param {String} name Adapter name
  * @param {Object} config Configuration options for the service
  */
@@ -148,21 +148,29 @@ metrics.trackPage('GoogleAnalytics', {
 
 There are 4 main methods implemented by the service, with the same argument signature:
 
-- `trackPage([analyticsName], options)` 
-  
+- `trackPage([analyticsName], options)`
+
   This is commonly used by analytics services to track page views. Due to the way Single Page Applications implement routing, you will need to call this on the `activate` hook of each route to track all page views.
 
 - `trackEvent([analyticsName], options)`
-  
+
   This is a general purpose method for tracking a named event in your application.
 
 - `identify([analyticsName], options)`
-  
+
   For analytics services that have identification functionality.
 
 - `alias([analyticsName], options)`
-  
+
   For services that implement it, this method notifies the analytics service that an anonymous user now has a unique identifier.
+
+##### Context
+
+Often you'll want to include things like `currentUser.name` with every event or page view that's tracked. Any properties that you bind to `metrics.context` will be merged into the options for every service call.
+
+    set('metrics.context.userName', 'Jimbo');
+    get('metrics').trackPage({page: 'page/1'});
+    // => {userName: 'Jimbo', page: 'page/1'}
 
 #### `link-to` API
 
@@ -185,7 +193,7 @@ ga('send', {
 });
 ```
 
-To add an attribute, just prefix it with `metrics` and enter it in camelcase. 
+To add an attribute, just prefix it with `metrics` and enter it in camelcase.
 
 ### Lazy Initialization
 
@@ -222,7 +230,7 @@ First, generate a new Metrics Adapter:
 $ ember generate metrics-adapter foo-bar
 ```
 
-This creates `app/metrics-adapters/foo-bar.js` and a unit test at `tests/unit/metrics-adapters/foo-bar-test.js`, which you should now customize. 
+This creates `app/metrics-adapters/foo-bar.js` and a unit test at `tests/unit/metrics-adapters/foo-bar-test.js`, which you should now customize.
 
 ### Required Methods
 

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 import sinon from 'sinon';
 
-const get = Ember.get;
+const { get, set } = Ember;
 let sandbox, metricsAdapters;
 
 moduleFor('service:metrics', 'Unit | Service | metrics', {
@@ -129,6 +129,16 @@ test('#invoke invokes the named method on a single activated adapter with no arg
 
   assert.ok(GoogleAnalyticsSpy.calledOnce, 'it invokes the track method on the adapter');
   assert.ok(GoogleAnalyticsStub.calledOnce, 'it invoked the Google Analytics method');
+});
+
+test('#invoke includes `context` properties', function(assert){
+  const service = this.subject({ metricsAdapters });
+  const GoogleAnalyticsSpy = sandbox.spy(get(service, '_adapters.GoogleAnalytics'), 'trackPage');
+
+  set(service, 'context.userName', "Jimbo");
+  service.invoke('trackPage', 'GoogleAnalytics', {page: 'page/1', title: 'page one'});
+
+  assert.ok(GoogleAnalyticsSpy.calledWith({userName: "Jimbo", page: 'page/1', title: 'page one'}));
 });
 
 test('it implements standard contracts', function(assert) {


### PR DESCRIPTION
Any properties bound to metrics.context will be merged into options for any calls to the service API