### PR TITLE
Don't pollute metrics.context with properties from service invocation

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -7,6 +7,7 @@ const {
   get,
   set,
   merge,
+  copy,
   A: emberArray,
   String: { dasherize }
 } = Ember;
@@ -102,7 +103,8 @@ export default Service.extend({
     const cachedAdapters = get(this, '_adapters');
     const allAdapterNames = keys(cachedAdapters);
     const [selectedAdapterNames, options] = args.length > 1 ? [[args[0]], args[1]] : [allAdapterNames, args[0]];
-    const mergedOptions = merge(get(this, 'context'), options);
+    const context = copy(get(this, 'context'));
+    const mergedOptions = merge(context, options);
 
     selectedAdapterNames
       .map((adapterName) => get(cachedAdapters, adapterName))

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -141,6 +141,17 @@ test('#invoke includes `context` properties', function(assert){
   assert.ok(GoogleAnalyticsSpy.calledWith({ userName: 'Jimbo', page: 'page/1', title: 'page one' }), 'it includes context properties');
 });
 
+test('#invoke does not leak options between calls', function(assert){
+  const service = this.subject({ metricsAdapters });
+  const GoogleAnalyticsSpy = sandbox.spy(get(service, '_adapters.GoogleAnalytics'), 'trackPage');
+
+  set(service, 'context.userName', 'Jimbo');
+  service.invoke('trackPage', 'GoogleAnalytics', { page: 'page/1', title: 'page one', callOne: true });
+  service.invoke('trackPage', 'GoogleAnalytics', { page: 'page/1', title: 'page one', callTwo: true });
+
+  assert.ok(GoogleAnalyticsSpy.calledWith({ userName: 'Jimbo', page: 'page/1', title: 'page one', callTwo: true }), 'it does not include options from previous call');
+});
+
 test('it implements standard contracts', function(assert) {
   const service = this.subject({ metricsAdapters });
   sandbox.stub(window.mixpanel);


### PR DESCRIPTION
Apologies for this one, I hadn't realised that Ember.merge does a destructive merge on the first argument. http://emberjs.com/api/#method_merge

This PR clones the context before merging the options in for a particular call ensuring there's no cross-contamination between calls.