### PR TITLE
Add metrics#enabled flag - defaults to true

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -37,6 +37,15 @@ export default Service.extend({
   context: null,
 
   /**
+   * Indicates whether calls to the service will be forwarded to the adapters
+   *
+   * @property context
+   * @type Boolean
+   * @default true
+   */
+  enabled: true,
+
+  /**
    * When the Service is created, activate adapters that were specified in the
    * configuration. This config is injected into the Service as
    * `metricsAdapters`.
@@ -100,6 +109,8 @@ export default Service.extend({
    * @return {Void}
    */
   invoke(methodName, ...args) {
+    if (!get(this, 'enabled')) { return; }
+
     const cachedAdapters = get(this, '_adapters');
     const allAdapterNames = keys(cachedAdapters);
     const [selectedAdapterNames, options] = args.length > 1 ? [[args[0]], args[1]] : [allAdapterNames, args[0]];

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -152,6 +152,16 @@ test('#invoke does not leak options between calls', function(assert){
   assert.ok(GoogleAnalyticsSpy.calledWith({ userName: 'Jimbo', page: 'page/1', title: 'page one', callTwo: true }), 'it does not include options from previous call');
 });
 
+test('it can be disabled', function(assert){
+  const service = this.subject({ metricsAdapters });
+  const GoogleAnalyticsSpy = sandbox.spy(get(service, '_adapters.GoogleAnalytics'), 'trackPage');
+
+  set(service, 'enabled', false);
+  service.invoke('trackPage', 'GoogleAnalytics', { page: 'page/1', title: 'page one' });
+
+  assert.notOk(GoogleAnalyticsSpy.called, 'it does not call adapters');
+});
+
 test('it implements standard contracts', function(assert) {
   const service = this.subject({ metricsAdapters });
   sandbox.stub(window.mixpanel);


### PR DESCRIPTION
Another little feature I need. Allows metrics service to be disabled with:

    metrics.set('enabled', false);