### PR TITLE
GA nonInteraction field

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -57,6 +57,11 @@ export default BaseAdapter.extend({
     const sendEvent = { hitType: 'event' };
     let gaEvent = {};
 
+    if (compactedOptions.nonInteraction) {
+      gaEvent.nonInteraction = compactedOptions.nonInteraction;
+      delete compactedOptions.nonInteraction;
+    }
+
     for (let key in compactedOptions) {
       const capitalizedKey = capitalize(key);
       gaEvent[`event${capitalizedKey}`] = compactedOptions[key];


### PR DESCRIPTION
Small feature request...

GA events can be passed an argument that is not prefixed with `event`: the argument is `nonInteraction`.

so this small patch just tests for the presence of a nonInteraction key on the passed-in options and addresses it before looping through the other keys.

example here: https://developers.google.com/analytics/devguides/collection/analyticsjs/events#non-interaction_events
description here: https://support.google.com/analytics/answer/1033068#NonInteractionEvents