### PR TITLE
Force Google Analytics to use SSL for mobile ember apps

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -34,7 +34,7 @@ export default BaseAdapter.extend({
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
       /* jshint ignore:end */
       
       if (hasOptions) {


### PR DESCRIPTION
Mobile ember applications can not use the current google analytics adapter because of the // prefix. The apps are served in a webview with file://. This causes the lookup to be local as opposed to the remote http/https google url.

I noticed the mixpanel adapter allows for a custom URL but figured that would be overkill for a simple SSL force for GA. Let me know if you would like to retain the current functionality with a URL override and I can open another PR.