### PR TITLE
Add Segment Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Writing your own adapters for currently unsupported analytics services is easy t
 
 1. `GoogleAnalytics`
   - `id`: [Property ID](https://support.google.com/analytics/answer/1032385?hl=en), e.g. `UA-XXXX-Y`
-2. `Mixpanel`
+1. `Mixpanel`
   - `token`: [Mixpanel token](https://mixpanel.com/help/questions/articles/where-can-i-find-my-project-token)
-3. `GoogleTagManager`
+1. `GoogleTagManager`
   - `id`: [Container ID](https://developers.google.com/tag-manager/quickstart), e.g. `GTM-XXXX`
 
   - `dataLayer`: An array containing a single POJO of information, e.g.:
@@ -25,8 +25,10 @@ Writing your own adapters for currently unsupported analytics services is easy t
       'visitorType': 'high-value'
     }];
     ```
-4. `KISSMetrics` (WIP)
-5. `CrazyEgg` (WIP)
+1. `Segment`
+  - `key`: [Segment key](https://segment.com/docs/libraries/analytics.js/quickstart/)
+1. `KISSMetrics` (WIP)
+1. `CrazyEgg` (WIP)
 
 ## Installing The Addon
 
@@ -65,6 +67,13 @@ module.exports = function(environment) {
         environments: ['production']
         config: {
           token: '0f76c037-4d76-4fce-8a0f-a9a8f89d1453'
+        }
+      },
+      {
+        name: 'Segment',
+        environments: ['production']
+        config: {
+          key: '4fce-8a0f-a9a8f89d1453'
         }
       },
       {

--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -1,0 +1,71 @@
+import Ember from 'ember';
+import canUseDOM from '../utils/can-use-dom';
+import { compact } from '../utils/object-transforms';
+import BaseAdapter from './base';
+
+const {
+  $,
+  assert,
+  copy,
+  get
+} = Ember;
+
+export default BaseAdapter.extend({
+  toStringExtension() {
+    return 'Segment';
+  },
+
+  init() {
+    const config = copy(get(this, 'config'));
+    const segmentKey = config.key;
+
+    assert(`[ember-metrics] You must pass a valid \`key\` to the ${this.toString()} adapter`, segmentKey);
+
+    if (canUseDOM) {
+      /* jshint ignore:start */
+      window.analytics=window.analytics||[],window.analytics.methods=["identify","group","track","page","pageview","alias","ready","on","once","off","trackLink","trackForm","trackClick","trackSubmit"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var key=window.analytics.methods[i];window.analytics[key]=window.analytics.factory(key)}window.analytics.load=function(t){if(!document.getElementById("analytics-js")){var a=document.createElement("script");a.type="text/javascript",a.id="analytics-js",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)}},window.analytics.SNIPPET_VERSION="2.0.9";
+      /* jshint ignore:end */
+      window.analytics.load(segmentKey);
+    }
+  },
+
+  alias(options = {}) {
+    const compactedOptions = compact(options);
+    const { alias, original } = compactedOptions;
+
+    if (original) {
+      window.analytics.alias(alias, original);
+    } else {
+      window.analytics.alias(alias);
+    }
+  },
+
+  identify(options = {}) {
+    const compactedOptions = compact(options);
+    const { distinctId } = compactedOptions;
+    delete compactedOptions.distinctId;
+
+    window.analytics.identify(distinctId, compactedOptions);
+  },
+
+  trackEvent(options = {}) {
+    const compactedOptions = compact(options);
+    const { event } = compactedOptions;
+    delete compactedOptions.event;
+
+    window.analytics.track(event, compactedOptions);
+  },
+
+  trackPage(options = {}) {
+    const compactedOptions = compact(options);
+    const { page } = compactedOptions;
+    delete compactedOptions.page;
+
+    window.analytics.page(page, compactedOptions);
+  },
+
+  willDestroy() {
+    $('script[src*="segment.com"]').remove();
+    delete window.analytics;
+  }
+});

--- a/tests/unit/metrics-adapters/segment-test.js
+++ b/tests/unit/metrics-adapters/segment-test.js
@@ -1,0 +1,77 @@
+import { moduleFor, test } from 'ember-qunit';
+import sinon from 'sinon';
+
+let sandbox, config;
+
+moduleFor('ember-metrics@metrics-adapter:segment', 'segment adapter', {
+  beforeEach() {
+    sandbox = sinon.sandbox.create();
+    config = {
+      key: 'SEGMENT_KEY'
+    };
+  },
+  afterEach() {
+    sandbox.restore();
+  }
+});
+
+test('#identify calls analytics with the right arguments', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'identify', () => {
+    return true;
+  });
+  adapter.identify({
+    distinctId: 123
+  });
+  assert.ok(stub.calledWith(123), 'it sends the correct arguments');
+});
+
+test('#trackEvent returns the correct response shape', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'track');
+  adapter.trackEvent({
+    event: 'Signed Up',
+    category: 'button',
+    action: 'click',
+    label: 'nav buttons',
+    value: 4
+  });
+  const expectedArguments = {
+    category: 'button',
+    action: 'click',
+    label: 'nav buttons',
+    value: 4
+  };
+
+  assert.ok(stub.calledWith('Signed Up', expectedArguments), 'track called with proper arguments');
+});
+
+test('#trackPage returns the correct response shape', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'page');
+  adapter.trackPage({
+    page: '/my-overridden-page?id=1',
+    title: 'my overridden page'
+  });
+  const expectedArguments = {
+    title: 'my overridden page'
+  };
+
+  assert.ok(stub.calledWith('/my-overridden-page?id=1', expectedArguments), 'page called with proper arguments');
+});
+
+test('#trackPage returns the correct response shape', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'page');
+  adapter.trackPage();
+
+  assert.ok(stub.calledWith(), 'page called with default arguments');
+});
+
+test('#alias returns the correct response shape', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'alias');
+  adapter.alias({ alias: 'foo', original: 'bar' });
+
+  assert.ok(stub.calledWith('foo', 'bar'), 'page called with default arguments');
+});


### PR DESCRIPTION
Implements a [Segment.js] wrapper. In terms of implementation, the
`ember-metrics` adapter API maps nicely to the Segment.js API:

* Ember-Metric's `identify` -> Segment's `identify`
* Ember-Metric's `alias` -> Segment's `alias`
* Ember-Metric's `trackEvent` -> Segment's `track`
* Ember-Metric's `trackPage` -> Segment's `page`

[Segment.js]: https://segment.com/docs/libraries/analytics.js/