### PR TITLE
config.metricsAdapters should default to an empty array

### DIFF
--- a/app/initializers/metrics.js
+++ b/app/initializers/metrics.js
@@ -2,7 +2,7 @@ import config from '../config/environment';
 
 export function initialize() {
   const application = arguments[1] || arguments[0];
-  const { metricsAdapters = {} } = config;
+  const { metricsAdapters = [] } = config;
   const { environment = 'development' } = config;
   const options = { metricsAdapters, environment };
 


### PR DESCRIPTION
`config.metricsAdapters` defaults to an empty hash which causes the [`getWithDefault`](https://github.com/poteto/ember-metrics/blob/develop/addon/services/metrics.js#L58) to an empty array never to be satisfied which causes [`filter`](https://github.com/poteto/ember-metrics/blob/develop/addon/services/metrics.js#L96) since it's an Object and not an Array.