### PR TITLE
Implement 'trackPage' in MixPanel adapter

### DIFF
--- a/addon/metrics-adapters/mixpanel.js
+++ b/addon/metrics-adapters/mixpanel.js
@@ -6,7 +6,8 @@ import BaseAdapter from './base';
 const {
   assert,
   $,
-  get
+  get,
+  merge
 } = Ember;
 const {
   without,
@@ -46,7 +47,7 @@ export default BaseAdapter.extend({
     }
   },
 
-  trackEvent(options ={}) {
+  trackEvent(options = {}) {
     const compactedOptions = compact(options);
     const { event } = compactedOptions;
     const props = without(compactedOptions, 'event');
@@ -56,6 +57,13 @@ export default BaseAdapter.extend({
     } else {
       window.mixpanel.track(event);
     }
+  },
+
+  trackPage(options = {}) {
+    const event = { event: 'page viewed' };
+    const mergedOptions = merge(event, options);
+
+    this.trackEvent(mergedOptions);
   },
 
   alias(options = {}) {

--- a/tests/unit/metrics-adapters/mixpanel-test.js
+++ b/tests/unit/metrics-adapters/mixpanel-test.js
@@ -16,7 +16,7 @@ moduleFor('ember-metrics@metrics-adapter:mixpanel', 'mixpanel adapter', {
 });
 
 test('#identify calls `mixpanel.identify` with the right arguments', function(assert) {
-  var adapter = this.subject({ config });
+  const adapter = this.subject({ config });
   const stub = sandbox.stub(window.mixpanel, 'identify', () => {
     return true;
   });
@@ -33,7 +33,7 @@ test('#identify calls `mixpanel.identify` with the right arguments', function(as
 });
 
 test('#trackEvent calls `mixpanel.track` with the right arguments', function(assert) {
-  var adapter = this.subject({ config });
+  const adapter = this.subject({ config });
   const stub = sandbox.stub(window.mixpanel, 'track', () => {
     return true;
   });
@@ -49,8 +49,24 @@ test('#trackEvent calls `mixpanel.track` with the right arguments', function(ass
   assert.ok(stub.secondCall.calledWith('Ate a cookie'), 'it sends the correct arguments');
 });
 
+test('#trackPage calls `mixpanel.track` with the right arguments', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.mixpanel, 'track', () => {
+    return true;
+  });
+  adapter.trackPage({
+    page: '/products/1'
+  });
+  adapter.trackPage({
+    event: 'Page View',
+    page: '/products/1'
+  });
+  assert.ok(stub.firstCall.calledWith('page viewed', { page: '/products/1' }), 'it sends the correct arguments and options');
+  assert.ok(stub.secondCall.calledWith('Page View', { page: '/products/1' }), 'it sends the correct arguments and options');
+});
+
 test('#alias calls `mixpanel.alias` with the right arguments', function(assert) {
-  var adapter = this.subject({ config });
+  const adapter = this.subject({ config });
   const stub = sandbox.stub(window.mixpanel, 'alias', () => {
     return true;
   });


### PR DESCRIPTION
As Mixpanel is mostly centred around Events as opposed to Page Views,
it doesn't strictly have an API for tracking page views. This is the
reason that the trackPage function was not initially implemented. However, it is
useful to track page views as events.

The implementation for the trackPage function is as suggested by the
[MixPanel docs](https://mixpanel.com/help/questions/articles/why-measure-events-vs-page-views)