### PR TITLE
Update to identify method for mixpanel adapter

### DIFF
--- a/addon/metrics-adapters/mixpanel.js
+++ b/addon/metrics-adapters/mixpanel.js
@@ -41,7 +41,8 @@ export default BaseAdapter.extend({
     const props = without(compactedOptions, 'distinctId');
 
     if (isPresent(props)) {
-      window.mixpanel.identify(distinctId, props);
+      window.mixpanel.identify(distinctId);
+      window.mixpanel.people.set(props);
     } else {
       window.mixpanel.identify(distinctId);
     }


### PR DESCRIPTION
Mixpanels API specifies that identify only sets a new user up with the passed in ID, so other properties about the user are not passed in.
https://mixpanel.com/help/reference/javascript-full-api-reference#mixpanel.identify
Instead it should pair `identify` with `people.set` to assign more details about the user to that user id
https://mixpanel.com/help/reference/javascript-full-api-reference#mixpanel.people.set

Another method should probably be included to just set the user information if it changes as once you've identified or aliased a user with the active session, updating the user with `people.set` should just use the previously identified or aliased user to update with the info passed into `people.set`