### PR TITLE
Use `Ember.assign()` if possible

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -7,12 +7,12 @@ const {
   isPresent,
   copy,
   assert,
-  merge,
   get,
   $,
   String: { capitalize },
 } = Ember;
 const { compact } = objectTransforms;
+const assign = Ember.assign || Ember.merge;
 
 export default BaseAdapter.extend({
   toStringExtension() {
@@ -36,7 +36,7 @@ export default BaseAdapter.extend({
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
       /* jshint ignore:end */
-      
+
       if (hasOptions) {
         window.ga('create', id, config);
       } else {
@@ -67,7 +67,7 @@ export default BaseAdapter.extend({
       gaEvent[`event${capitalizedKey}`] = compactedOptions[key];
     }
 
-    const event = merge(sendEvent, gaEvent);
+    const event = assign(sendEvent, gaEvent);
     window.ga('send', event);
 
     return event;
@@ -77,7 +77,7 @@ export default BaseAdapter.extend({
     const compactedOptions = compact(options);
     const sendEvent = { hitType: 'pageview' };
 
-    const event = merge(sendEvent, compactedOptions);
+    const event = assign(sendEvent, compactedOptions);
     window.ga('send', event);
 
     return event;

--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -6,12 +6,12 @@ import BaseAdapter from './base';
 const {
   assert,
   get,
-  merge,
   set,
   $,
   getWithDefault,
   String: { capitalize }
 } = Ember;
+const assign = Ember.assign || Ember.merge;
 const {
   compact
 } = objectTransforms;
@@ -67,7 +67,7 @@ export default BaseAdapter.extend({
       event: compactedOptions['event'] || 'pageview'
     };
 
-    const pageEvent = merge(sendEvent, compactedOptions);
+    const pageEvent = assign(sendEvent, compactedOptions);
 
     window[dataLayer].push(pageEvent);
 

--- a/addon/metrics-adapters/mixpanel.js
+++ b/addon/metrics-adapters/mixpanel.js
@@ -7,13 +7,13 @@ const {
   assert,
   $,
   get,
-  merge
 } = Ember;
 const {
   without,
   compact,
   isPresent
 } = objectTransforms;
+const assign = Ember.assign || Ember.merge;
 
 export default BaseAdapter.extend({
   toStringExtension() {
@@ -61,7 +61,7 @@ export default BaseAdapter.extend({
 
   trackPage(options = {}) {
     const event = { event: 'page viewed' };
-    const mergedOptions = merge(event, options);
+    const mergedOptions = assign(event, options);
 
     this.trackEvent(mergedOptions);
   },

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -7,12 +7,12 @@ const {
   assert,
   get,
   set,
-  merge,
   copy,
   A: emberArray,
   String: { dasherize }
 } = Ember;
 const { keys } = Object;
+const assign = Ember.assign || Ember.merge;
 
 export default Service.extend({
   /**
@@ -123,7 +123,7 @@ export default Service.extend({
     const allAdapterNames = keys(cachedAdapters);
     const [selectedAdapterNames, options] = args.length > 1 ? [[args[0]], args[1]] : [allAdapterNames, args[0]];
     const context = copy(get(this, 'context'));
-    const mergedOptions = merge(context, options);
+    const mergedOptions = assign(context, options);
 
     selectedAdapterNames
       .map((adapterName) => get(cachedAdapters, adapterName))


### PR DESCRIPTION
As `Ember.merge` is deprecated since `Ember 2.5.0`.