### PR TITLE
Avoid exceptions when metrics#invoke is called on a disabled adapter

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -127,7 +127,7 @@ export default Service.extend({
 
     selectedAdapterNames
       .map((adapterName) => get(cachedAdapters, adapterName))
-      .forEach((adapter) => adapter[methodName](mergedOptions));
+      .forEach((adapter) => adapter && adapter[methodName](mergedOptions));
   },
 
   /**

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -135,6 +135,12 @@ test('#invoke invokes the named method on a single activated adapter', function(
   assert.equal(MixpanelSpy.callCount, 0, 'it does not invoke other adapters');
 });
 
+test("#invoke doesn't error when asked to use a single deactivated adapter", function(assert) {
+  const service = this.subject({ options });
+  service.invoke('trackEvent', 'Trackmaster2000', {});
+  assert.ok(true, 'No exception was thrown');
+});
+
 test('#invoke invokes the named method on a single activated adapter with no arguments', function(assert) {
   const service = this.subject({ options });
   const GoogleAnalyticsStub = sandbox.stub(window, 'ga');


### PR DESCRIPTION
This seems like the simplest implementation, but I'd be happy to update it with an `Ember.warn` in cases where the adapter cannot be found.

Fixes #83