### PR TITLE
Fix 2.8.x contains > includes deprecation + Works with 1.x

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -195,6 +195,6 @@ export default Service.extend({
     environments = environments || ['all'];
     const wrappedEnvironments = emberArray(environments);
 
-    return wrappedEnvironments.contains('all') || wrappedEnvironments.contains(appEnvironment);
+    return wrappedEnvironments.includes('all') || wrappedEnvironments.includes(appEnvironment);
   }
 });

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-getowner-polyfill": "^1.0.0",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This also uses the polyfill so we can support older versions of ember.

This should be merged instead of #95 because it polyfills so 1.13.x users will not break.