### PR TITLE
Replace `includes` with `indexOf` to run in FastBoot

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -195,6 +195,6 @@ export default Service.extend({
     environments = environments || ['all'];
     const wrappedEnvironments = emberArray(environments);
 
-    return wrappedEnvironments.includes('all') || wrappedEnvironments.includes(appEnvironment);
+    return wrappedEnvironments.indexOf('all') > -1 || wrappedEnvironments.indexOf(appEnvironment) > -1;
   }
 });


### PR DESCRIPTION
To fix this error.

```javascript
Ember FastBoot running at http://[::]:3000
TypeError: wrappedEnvironments.contains is not a function
```