### PR TITLE
Update path view tracking example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ const Router = Ember.Router.extend({
 
   _trackPage() {
     Ember.run.scheduleOnce('afterRender', this, () => {
-      const page = document.location.pathname;
+      const page = this.get('url');
       const title = this.getWithDefault('currentRouteName', 'unknown');
 
       Ember.get(this, 'metrics').trackPage({ page, title });


### PR DESCRIPTION
I was setting this thing up today and wanted to track page views.  I happen to be hosting my Ember app on Github Pages so I need to use a hash-based URL.  The example code here reported every URL the same way, so I dug around and found that `this.get("url")` reported a value that actually reflects the real URL, regardless of the location type.