### PR TITLE
Add the willDestroy method to the adapter stub

### DIFF
--- a/blueprints/metrics-adapter/files/__root__/metrics-adapters/__name__.js
+++ b/blueprints/metrics-adapter/files/__root__/metrics-adapters/__name__.js
@@ -23,5 +23,9 @@ export default <%= baseClass %>.extend({
 
   alias() {
 
+  },
+
+  willDestroy() {
+    
   }
 });


### PR DESCRIPTION
 Add the willDestroy method to the stub generated by `ember generate metrics-adapter` as it's a required method. Fixes #105 