### PR TITLE
Add Intercom adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Writing your own adapters for currently unsupported analytics services is easy t
   - `piwikUrl`: [Tracker URL](http://developer.piwik.org/guides/tracking-javascript-guide)
   - `siteId`: [Site Id](http://developer.piwik.org/guides/tracking-javascript-guide)
 
+1. `Intercom`
+  - `appId`: [App ID](https://docs.intercom.com/help-and-faqs/getting-set-up/where-can-i-find-my-app-id)
+
 1. `KISSMetrics` (WIP)
 1. `CrazyEgg` (WIP)
 
@@ -87,6 +90,13 @@ module.exports = function(environment) {
         config: {
           piwikUrl: 'http://piwik.my.com',
           siteId: 42
+        }
+      },
+      {
+        name: 'Intercom',
+        environments: ['production'],
+        config: {
+          appId: 'def1abc2'
         }
       },
       {

--- a/addon/metrics-adapters/intercom.js
+++ b/addon/metrics-adapters/intercom.js
@@ -1,0 +1,81 @@
+import Ember from 'ember';
+import canUseDOM from '../utils/can-use-dom';
+import objectTransforms from '../utils/object-transforms';
+import BaseAdapter from './base';
+
+const {
+  $,
+  assert,
+  get,
+} = Ember;
+const {
+  compact,
+  without,
+} = objectTransforms;
+const assign = Ember.assign || Ember.merge;
+
+export default BaseAdapter.extend({
+  booted: false,
+
+  toStringExtension() {
+    return 'Intercom';
+  },
+
+  init() {
+    const { appId } = get(this, 'config');
+
+    assert(`[ember-metrics] You must pass a valid \`appId\` to the ${this.toString()} adapter`, appId);
+
+    if (canUseDOM) {
+      /* jshint ignore:start */
+      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
+      s.src=`https://widget.intercom.io/widget/${appId}`;
+      var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+      /* jshint ignore:end */
+    }
+  },
+
+  identify(options = {}) {
+    const { appId } = get(this, 'config');
+    const compactedOptions = compact(options);
+    const { distinctId } = compactedOptions;
+    const props = without(compactedOptions, 'distinctId');
+
+    props.app_id = appId;
+    if (distinctId) {
+      props.user_id = distinctId;
+    }
+
+    assert(`[ember-metrics] You must pass \`distinctId\` or \`email\` to \`identify()\` when using the ${this.toString()} adapter`, props.email || props.user_id);
+
+    const method = this.booted ? 'update' : 'boot';
+    if (canUseDOM) {
+      window.Intercom(method, props);
+      this.booted = true;
+    }
+  },
+
+  trackEvent(options = {}) {
+    const compactedOptions = compact(options);
+    const { event } = compactedOptions;
+    const props = without(compactedOptions, 'event');
+
+    if (canUseDOM) {
+      window.Intercom('trackEvent', event, props);
+    }
+  },
+
+  trackPage(options = {}) {
+    const event = { event: 'page viewed' };
+    const mergedOptions = assign(event, options);
+
+    this.trackEvent(mergedOptions);
+  },
+
+  willDestroy() {
+    if (canUseDOM) {
+      $('script[src*="intercom"]').remove();
+      delete window.Intercom;
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "google analytics",
     "google tag manager",
     "mixpanel",
-    "piwik"
+    "piwik",
+    "intercom"
   ],
   "dependencies": {
     "broccoli-funnel": "^1.0.1",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -39,6 +39,14 @@ module.exports = function(environment) {
         }
       },
       {
+        // if `environments` is undefined, it defaults to all
+        name: 'Intercom',
+        // environments: ['all'],
+        config: {
+          appId: 'def1abc2'
+        }
+      },
+      {
         name: 'LocalDummyAdapter',
         environments: ['all'],
         config: {

--- a/tests/unit/metrics-adapters/intercom-test.js
+++ b/tests/unit/metrics-adapters/intercom-test.js
@@ -1,0 +1,113 @@
+import { moduleFor, test } from 'ember-qunit';
+import sinon from 'sinon';
+
+let sandbox, config;
+
+moduleFor('ember-metrics@metrics-adapter:intercom', 'intercom adapter', {
+  beforeEach() {
+    sandbox = sinon.sandbox.create();
+    config = {
+      appId: 'def1abc2'
+    };
+  },
+  afterEach() {
+    sandbox.restore();
+  }
+});
+
+test('#identify with `distinctId` calls `Intercom()` with the right arguments', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'Intercom', () => {
+    return true;
+  });
+  adapter.identify({
+    distinctId: 123,
+    foo: 'bar'
+  });
+  adapter.identify({
+    distinctId: 123
+  });
+  assert.ok(stub.firstCall.calledWith('boot', { app_id: 'def1abc2', foo: 'bar', user_id: 123 }), 'it sends the correct arguments');
+  assert.ok(stub.secondCall.calledWith('update', { app_id: 'def1abc2', user_id: 123 }), 'it sends the correct arguments');
+});
+
+test('#identify with `email` calls `Intercom()` with the right arguments', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'Intercom', () => {
+    return true;
+  });
+  adapter.identify({
+    email: 'tomster@ember.js',
+    foo: 'bar'
+  });
+  adapter.identify({
+    email: 'tomster@ember.js'
+  });
+  assert.ok(stub.firstCall.calledWith('boot', { app_id: 'def1abc2', email: 'tomster@ember.js', foo: 'bar' }), 'it sends the correct arguments');
+  assert.ok(stub.secondCall.calledWith('update', { app_id: 'def1abc2', email: 'tomster@ember.js' }), 'it sends the correct arguments');
+});
+
+test('#identify without `distinctId` or `email` throws', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'Intercom', () => {
+    return true;
+  });
+  assert.throws(() => {
+    adapter.identify({
+      foo: 'bar'
+    });
+  }, /You must pass `distinctId` or `email`/, 'exception is thrown');
+  assert.equal(stub.callCount, 0, 'Intercom() is not called');
+});
+
+test('#identify calls `Intercom()` with `boot` on initial call, then `update` on subsequent calls', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'Intercom', () => {
+    return true;
+  });
+  adapter.identify({
+    distinctId: 123
+  });
+  adapter.identify({
+    distinctId: 123
+  });
+  adapter.identify({
+    distinctId: 123
+  });
+  assert.ok(stub.firstCall.calledWith('boot', { app_id: 'def1abc2', user_id: 123 }), 'it sends the correct arguments');
+  assert.ok(stub.secondCall.calledWith('update', { app_id: 'def1abc2', user_id: 123 }), 'it sends the correct arguments');
+  assert.ok(stub.thirdCall.calledWith('update', { app_id: 'def1abc2', user_id: 123 }), 'it sends the correct arguments');
+});
+
+test('#trackEvent calls `Intercom()` with the right arguments', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'Intercom', () => {
+    return true;
+  });
+  adapter.trackEvent({
+    event: 'Video played',
+    videoLength: 213,
+    id: 'hY7gQr0'
+  });
+  adapter.trackEvent({
+    event: 'Ate a cookie'
+  });
+  assert.ok(stub.firstCall.calledWith('trackEvent', 'Video played', { videoLength: 213, id: 'hY7gQr0' }), 'it sends the correct arguments');
+  assert.ok(stub.secondCall.calledWith('trackEvent', 'Ate a cookie'), 'it sends the correct arguments');
+});
+
+test('#trackPage calls `Intercom()` with the right arguments', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'Intercom', () => {
+    return true;
+  });
+  adapter.trackPage({
+    page: '/products/1'
+  });
+  adapter.trackPage({
+    event: 'Page View',
+    page: '/products/1'
+  });
+  assert.ok(stub.firstCall.calledWith('trackEvent', 'page viewed', { page: '/products/1' }), 'it sends the correct arguments and options');
+  assert.ok(stub.secondCall.calledWith('trackEvent', 'Page View', { page: '/products/1' }), 'it sends the correct arguments and options');
+});


### PR DESCRIPTION
This PR adds an Intercom adapter 💬 

It follows the Mixpanel adapter and defaults to a `page viewed` event for `trackPage()` calls. It also allows for `identify()` calls with `distinctId` _or_ `email` to identify users.

Fixes #107