### PR TITLE
Load the Intercom API correctly

### DIFF
--- a/addon/metrics-adapters/intercom.js
+++ b/addon/metrics-adapters/intercom.js
@@ -28,9 +28,9 @@ export default BaseAdapter.extend({
 
     if (canUseDOM) {
       /* jshint ignore:start */
-      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
+      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',{});}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
       s.src=`https://widget.intercom.io/widget/${appId}`;
-      var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+      var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);} l(); }})()
       /* jshint ignore:end */
     }
   },


### PR DESCRIPTION
The browsers load event has probably already fired when the service initializes.

Load the Intercom API directly instead of binding it to the load event.

Fixes #109 