### PR TITLE
Removes usage of `Ember.K`

### DIFF
--- a/tests/dummy/app/metrics-adapters/local-dummy-adapter.js
+++ b/tests/dummy/app/metrics-adapters/local-dummy-adapter.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import BaseAdapter from 'ember-metrics/metrics-adapters/base';
 
 export default BaseAdapter.extend({

--- a/tests/dummy/app/metrics-adapters/local-dummy-adapter.js
+++ b/tests/dummy/app/metrics-adapters/local-dummy-adapter.js
@@ -6,6 +6,6 @@ export default BaseAdapter.extend({
     return 'LocalDummy';
   },
 
-  init: Ember.K,
-  willDestroy: Ember.K
+  init() {},
+  willDestroy() {}
 });

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 import sinon from 'sinon';
 
-const { get, set, K } = Ember;
+const { get, set } = Ember;
 const environment = 'test';
 let sandbox, metricsAdapters, options;
 
@@ -44,7 +44,7 @@ moduleFor('service:metrics', 'Unit | Service | metrics', {
       environment
     };
 
-    window.ga = window.ga || K;
+    window.ga = window.ga || function() {};
   },
 
   afterEach() {


### PR DESCRIPTION
Replace Ember API usage with JavaScript native syntax.