### PR TITLE
Add GTM environments support

### DIFF
--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -33,13 +33,19 @@ export default BaseAdapter.extend({
     set(this, 'dataLayer', dataLayer);
 
     if (canUseDOM) {
-      /* jshint ignore:start */
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script',get(this, 'dataLayer'),id);
-      /* jshint ignore:end */
+      (function(w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({
+          'gtm.start': new Date().getTime(),
+          event: 'gtm.js'
+        });
+        var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l !== 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', get(this, 'dataLayer'), id);
     }
   },
 

--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -25,8 +25,9 @@ export default BaseAdapter.extend({
 
   init() {
     const config = get(this, 'config');
-    const { id } = config;
-    const dataLayer = getWithDefault(config,'dataLayer', 'dataLayer');
+    const { id, envParams } = config;
+    const dataLayer = getWithDefault(config, 'dataLayer', 'dataLayer');
+    const envParamsString = envParams ? `&${envParams}`: '';
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
@@ -43,7 +44,7 @@ export default BaseAdapter.extend({
             j = d.createElement(s),
             dl = l !== 'dataLayer' ? '&l=' + l : '';
         j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + envParamsString;
         f.parentNode.insertBefore(j, f);
       })(window, document, 'script', get(this, 'dataLayer'), id);
     }


### PR DESCRIPTION
Google Tag Manager now supports environments within the same container ID. To use a custom environment, we need to append parameters to the GTM script url.

This Pull Request add the ability to add a variable `envParams` in the _GoogleTagManager_ adapter config which should look like that: `envParams: "gtm_auth=xxxxx&gtm_preview=env-xx&gtm_cookies_win=x"`

@poteto What do you think?

closes https://github.com/poteto/ember-metrics/issues/84