### PR TITLE
Add an example to clarify context setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ Ember.set(this, 'metrics.context.userName', 'Jimbo');
 Ember.get(this, 'metrics').trackPage({ page: 'page/1' }); // { userName: 'Jimbo', page: 'page/1' }
 ```
 
+To include the same context in every call, add the metrics service and set the context in the beforeModel hook of your application.js route.  For example:
+```
+beforeModel() {
+  this.set('metrics.context', {userName: 'Jimbo'});
+}
+```
+
 ### API
 
 #### Service API


### PR DESCRIPTION
@poteto it took me some digging to figure out how to get the context portion set up.  I thought providing an example may help others move more quickly.  Awesome addon though!  Being able to set the context saved a lot of extra legwork.