### PR TITLE
fix ember-getowner-polyfill deprication

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   Service,
@@ -8,6 +7,7 @@ const {
   get,
   set,
   copy,
+  getOwner,
   A: emberArray,
   String: { dasherize }
 } = Ember;

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.0",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Fix for deprecation: 
```
ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]
```