### PR TITLE
Use https:// scheme for Facebook and GTM adapters

### DIFF
--- a/addon/metrics-adapters/facebook-pixel.js
+++ b/addon/metrics-adapters/facebook-pixel.js
@@ -28,7 +28,7 @@ export default BaseAdapter.extend({
       n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
       n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
       t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-      document,'script','//connect.facebook.net/en_US/fbevents.js');
+      document,'script','https://connect.facebook.net/en_US/fbevents.js');
       /* jshint ignore:end */
 
       window.fbq('init', id);

--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -37,7 +37,7 @@ export default BaseAdapter.extend({
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script',get(this, 'dataLayer'),id);
       /* jshint ignore:end */
     }


### PR DESCRIPTION
Using protocol-relative URLs for these adapters fails when the Ember app
is loaded from a file:// URL, as happens when running as a hybrid
mobile app. Always using HTTPS for these interactions should be safe
in all browsers that Ember supports.