### PR TITLE
Adds debugging and tracing options to Google Analytics adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ module.exports = function(environment) {
         name: 'GoogleAnalytics',
         environments: ['development', 'production'],
         config: {
-          id: 'UA-XXXX-Y'
+          id: 'UA-XXXX-Y',
+          // Use `analytics_debug.js` in development
+          debug: environment === 'development',
+          // Use verbose tracing of GA events
+          trace: environment === 'development',
+          // Ensure development env hits aren't sent to GA
+          sendHitTask: environment !== 'development'
         }
       },
       {

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -72,6 +72,7 @@ export default BaseAdapter.extend({
   trackEvent(options = {}) {
     const compactedOptions = compact(options);
     const sendEvent = { hitType: 'event' };
+    const eventKeys = ['category', 'action', 'label', 'value'];
     let gaEvent = {};
 
     if (compactedOptions.nonInteraction) {
@@ -80,8 +81,12 @@ export default BaseAdapter.extend({
     }
 
     for (let key in compactedOptions) {
-      const capitalizedKey = capitalize(key);
-      gaEvent[`event${capitalizedKey}`] = compactedOptions[key];
+      if (eventKeys.includes(key)) {
+        const capitalizedKey = capitalize(key);
+        gaEvent[`event${capitalizedKey}`] = compactedOptions[key];
+      } else {
+        gaEvent[key] = compactedOptions[key];
+      }
     }
 
     const event = assign(sendEvent, gaEvent);

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -21,27 +21,42 @@ export default BaseAdapter.extend({
 
   init() {
     const config = copy(get(this, 'config'));
-    const { id } = config;
+    const { id, sendHitTask, trace } = config;
+    let { debug } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
     delete config.id;
 
+    if (debug) { delete config.debug; }
+    if (sendHitTask) { delete config.sendHitTask; }
+    if (trace) { delete config.trace; }
+
     const hasOptions = isPresent(Object.keys(config));
 
     if (canUseDOM) {
+
       /* jshint ignore:start */
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      })(window,document,'script',`https://www.google-analytics.com/analytics${debug ? '_debug' : ''}.js`,'ga');
       /* jshint ignore:end */
+
+      if (trace === true) {
+        window.ga_debug = { trace: true };
+      }
 
       if (hasOptions) {
         window.ga('create', id, config);
       } else {
         window.ga('create', id, 'auto');
       }
+
+      if (sendHitTask === false) {
+        window.ga('set', 'sendHitTask', null);
+      }
+
     }
   },
 

--- a/tests/unit/metrics-adapters/google-analytics-test.js
+++ b/tests/unit/metrics-adapters/google-analytics-test.js
@@ -33,14 +33,16 @@ test('#trackEvent returns the correct response shape', function(assert) {
     category: 'button',
     action: 'click',
     label: 'nav buttons',
-    value: 4
+    value: 4,
+    dimension1: true
   });
   const expectedResult = {
     hitType: 'event',
     eventCategory: 'button',
     eventAction: 'click',
     eventLabel: 'nav buttons',
-    eventValue: 4
+    eventValue: 4,
+    dimension1: true
   };
 
   assert.deepEqual(result, expectedResult, 'it sends the correct response shape');


### PR DESCRIPTION
The following PR enables [Google Analytics debugging](https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging) and tracing. For example:

```javascript
ENV.metricsAdapters = [{
  name: 'GoogleAnalytics',
  environments: ['development', 'production'],
  config: {
    id: 'UA-26778140-7',

    // Ensures analytics_debug.js is initialized in development
    //
    debug: environment === 'development', 

    // Ensures full tracing of GA events in development
    //
    trace: environment === 'development',

    // Ensures events aren't sent to GA in development mode
    //
    sendHitTask: environment !== 'development'
  }
}];
```

The PR also fixes the mishandling of keys from the `trackEvent` function in a slightly neater manner than #103 and extends the test to ensure it works.