### PR TITLE
use makeArray to include/exclude adaptors

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -121,7 +121,7 @@ export default Service.extend({
 
     const cachedAdapters = get(this, '_adapters');
     const allAdapterNames = keys(cachedAdapters);
-    const [selectedAdapterNames, options] = args.length > 1 ? [[args[0]], args[1]] : [allAdapterNames, args[0]];
+    const [selectedAdapterNames, options] = args.length > 1 ? [Ember.makeArray(args[0]), args[1]] : [allAdapterNames, args[0]];
     const context = copy(get(this, 'context'));
     const mergedOptions = assign(context, options);
 

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -7,6 +7,7 @@ const {
   get,
   set,
   copy,
+  makeArray,
   A: emberArray,
   String: { dasherize },
   getOwner
@@ -121,7 +122,7 @@ export default Service.extend({
 
     const cachedAdapters = get(this, '_adapters');
     const allAdapterNames = keys(cachedAdapters);
-    const [selectedAdapterNames, options] = args.length > 1 ? [Ember.makeArray(args[0]), args[1]] : [allAdapterNames, args[0]];
+    const [selectedAdapterNames, options] = args.length > 1 ? [makeArray(args[0]), args[1]] : [allAdapterNames, args[0]];
     const context = copy(get(this, 'context'));
     const mergedOptions = assign(context, options);
 

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -135,6 +135,29 @@ test('#invoke invokes the named method on a single activated adapter', function(
   assert.equal(MixpanelSpy.callCount, 0, 'it does not invoke other adapters');
 });
 
+test('#invoke invokes the named methods on a whitelist of activated adapters', function(assert) {
+  const service = this.subject({ options });
+  const MixpanelStub = sandbox.stub(window.mixpanel, 'identify');
+  const GoogleAnalyticsStub = sandbox.stub(window, 'ga');
+  const GoogleAnalyticsSpy = sandbox.spy(get(service, '_adapters.GoogleAnalytics'), 'identify');
+  const MixpanelSpy = sandbox.spy(get(service, '_adapters.Mixpanel'), 'identify');
+  const LocalDummyAdapterSpy = sandbox.spy(get(service, '_adapters.LocalDummyAdapter'), 'trackEvent');
+  const opts = {
+    userId: '1e810c197e',
+    name: 'Bill Limbergh',
+    email: 'bill@initech.com'
+  };
+  service.invoke('identify', ['GoogleAnalytics', 'Mixpanel'], opts);
+
+  assert.ok(GoogleAnalyticsSpy.calledOnce, 'it invokes the identify method on the adapter');
+  assert.ok(GoogleAnalyticsSpy.calledWith(opts), 'it invokes with the correct arguments');
+  assert.ok(GoogleAnalyticsStub.calledOnce, 'it invoked the GoogleAnalytics method');
+  assert.ok(MixpanelSpy.calledOnce, 'it invokes the identify method on the adapter');
+  assert.ok(MixpanelSpy.calledWith(opts), 'it invokes with the correct arguments');
+  assert.ok(MixpanelStub.calledOnce, 'it invoked the Mixpanel method');
+  assert.equal(LocalDummyAdapterSpy.callCount, 0, 'it does not invoke other adapters');
+});
+
 test("#invoke doesn't error when asked to use a single deactivated adapter", function(assert) {
   const service = this.subject({ options });
   service.invoke('trackEvent', 'Trackmaster2000', {});


### PR DESCRIPTION
When I call 
```js
this.get('metrics').trackPage();
```
I can only pass the adaptor that I want to target, or target all adaptors. It would be nice if we can also pass an array of adaptors we want to target. In that case you can target a few adaptors that you want without duplication code.

**Example:** 
If I have the following adaptors in my config `GoogleAnalytics`, `Mixpanel`, `GoogleTagManager`. And I don't want to target `GoogleTagManager`, I could do
```js
this.get('metrics').trackPage(['GoogleAnalytics', 'Mixpanel'], { page, title });
```