### PR TITLE
Instantiate adapters with container

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -158,7 +158,7 @@ export default Service.extend({
     const Adapter = this._lookupAdapter(name);
     assert(`[ember-metrics] Could not find metrics adapter ${name}.`, Adapter);
 
-    return Adapter.create({ this: this, config });
+    return Adapter.create({ this: this, config, container: getOwner(this) });
   },
 
   /**


### PR DESCRIPTION
We are having a custom adapter that uses an injected service.
Since ember 2.13 we are getting the following error:

```
Assertion Failed: Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.
```

This pull request adds the container when instantiating adapters, which resolves the issue.