### PR TITLE
Removes flag MODEL_FACTORY_INJECTIONS and improve ember syntax

### DIFF
--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -6,7 +6,7 @@ moduleForAcceptance('Acceptance | application');
 test('visiting /', function(assert) {
   visit('/');
 
-  andThen(function() {
+  andThen(() => {
     assert.equal(find('*').text(), 'bar');
   });
 });

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,11 +3,10 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
+const { Application } = Ember;
 let App;
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,12 +1,14 @@
 import Ember from 'ember';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const { Router } = Ember;
+
+const EmRouter = Ember.Router.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });
 
-Router.map(function() {
+EmRouter.map(() => {
 });
 
 export default Router;

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
-  metrics: Ember.inject.service(),
+const { Route, inject: { service }, get } = Ember
+
+export default Route.extend({
+  metrics: service(),
 
   setupController(controller) {
-    this.get('metrics').trackEvent({ controller });
+    get(this, 'metrics').trackEvent({ controller });
   }
 });

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { run } = Ember;
+
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,11 +2,13 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
-export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+const { merge, run } = Ember;
 
-  return Ember.run(() => {
+export default function startApp(attrs) {
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
+
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/unit/metrics-adapters/facebook-pixel-test.js
+++ b/tests/unit/metrics-adapters/facebook-pixel-test.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 import sinon from 'sinon';
 
+const { RSVP, run } = Ember;
+
 let config, fbq, subject;
 
 moduleFor('ember-metrics@metrics-adapter:facebook-pixel', 'facebook-pixel adapter', {
@@ -21,7 +23,7 @@ moduleFor('ember-metrics@metrics-adapter:facebook-pixel', 'facebook-pixel adapte
 });
 
 function waitForScripts() {
-  return new Ember.RSVP.Promise(resolve => {
+  return new RSVP.Promise(resolve => {
     function init() {
       fbq = sinon.spy(window, 'fbq');
       resolve();
@@ -46,7 +48,7 @@ function waitForScripts() {
         }
       } else {
         // generic script hasn't run yet
-        Ember.run.later(wait, 10);
+        run.later(wait, 10);
       }
     })();
   });


### PR DESCRIPTION
Removing this flag due to warning and improve ember syntax/ES6

This flag is needless for project with ember-cli >= 2.13

https://emberjs.com/deprecations/v2.x/#toc_id-ember-metal-model_factory_injections