### PR TITLE
Fix tree shaking adapters

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,11 +70,10 @@ module.exports = {
     this.whitelisted = uniqueStrings(discovered.map(normalize));
   },
 
-  treeForAddon: function() {
-    // see: https://github.com/ember-cli/ember-cli/issues/4463
-    var tree = this._super.treeForAddon.apply(this, arguments);
+  treeForAddon: function(tree) {
+    tree = this.filterAdapters(tree, new RegExp('metrics\-adapters\/', 'i'));
 
-    return this.filterAdapters(tree, new RegExp('^modules\/' + this.name + '\/metrics\-adapters\/', 'i'));
+    return this._super.treeForAddon.call(this, tree);
   },
 
   filterAdapters: function(tree, regex) {


### PR DESCRIPTION
Seems that tree shaking is not working properly, it still loads all adapters even if we specify them.
Referenced from this [PR](https://github.com/kaliber5/ember-bootstrap/pull/263), it should fix the issue.