### PR TITLE
Allow Google Analytics plugins to be specified in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ module.exports = function(environment) {
           // Use verbose tracing of GA events
           trace: environment === 'development',
           // Ensure development env hits aren't sent to GA
-          sendHitTask: environment !== 'development'
+          sendHitTask: environment !== 'development',
+          // Specify Google Analytics plugins
+          require: ['ecommerce']
         }
       },
       {

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -21,12 +21,13 @@ export default BaseAdapter.extend({
 
   init() {
     const config = copy(get(this, 'config'));
-    const { id, sendHitTask, trace } = config;
+    const { id, sendHitTask, trace, require } = config;
     let { debug } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
     delete config.id;
+    delete config.require;
 
     if (debug) { delete config.debug; }
     if (sendHitTask) { delete config.sendHitTask; }
@@ -51,6 +52,12 @@ export default BaseAdapter.extend({
         window.ga('create', id, config);
       } else {
         window.ga('create', id, 'auto');
+      }
+      
+      if (require) {
+        require.forEach((plugin) => {
+          window.ga('require', plugin);
+        });
       }
 
       if (sendHitTask === false) {

--- a/tests/unit/metrics-adapters/google-analytics-test.js
+++ b/tests/unit/metrics-adapters/google-analytics-test.js
@@ -7,12 +7,22 @@ moduleFor('ember-metrics@metrics-adapter:google-analytics', 'google-analytics ad
   beforeEach() {
     sandbox = sinon.sandbox.create();
     config = {
-      id: 'UA-XXXX-Y'
+      id: 'UA-XXXX-Y',
+      require: ['ecommerce']
     };
   },
   afterEach() {
     sandbox.restore();
   }
+});
+
+test('#init calls ga for any plugins specified', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'ga', () => {
+    return true;
+  });
+  adapter.init();
+  assert.ok(stub.calledWith('require', 'ecommerce'), 'it sends the correct arguments');
 });
 
 test('#identify calls ga with the right arguments', function(assert) {


### PR DESCRIPTION
Allows specifying [Google Analytics plugins](https://developers.google.com/analytics/devguides/collection/analyticsjs/using-plugins) in config.