### PR TITLE
Update ember-getowner-polyfill version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "ember-cli-babel": "^6.1.0",
-    "ember-getowner-polyfill": "^1.0.0",
+    "ember-getowner-polyfill": "^2.0.0",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This version removes a deprecation warning which is OK here because
getOwner is never being imported it is always getting pulled off of
Ember directly.