### PR TITLE
Ensure filterAdapters functions correclty in new ember-cli's

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = {
     // see: https://github.com/ember-cli/ember-cli/issues/4463
     var tree = this._super.treeForAddon.apply(this, arguments);
 
-    return this.filterAdapters(tree, new RegExp('^modules\/' + this.name + '\/metrics\-adapters\/', 'i'));
+    return this.filterAdapters(tree, new RegExp('^(?:modules\/)?' + this.name + '\/metrics\-adapters\/', 'i'));
   },
 
   filterAdapters: function(tree, regex) {


### PR DESCRIPTION
In older versions of ember-cli the tree passed to treeForAddon included
the string `modules/` in more recent (I believe 2.13 or 2.14) this
string is not present.

This change allows for it to match both the old and new style.

Noticed this with broccoli-concat-analyzer:

![combined-ember-metric-fix](https://user-images.githubusercontent.com/75710/30120639-72dd67fc-92f7-11e7-8047-a89c377efa3d.png)
