### PR TITLE
Fix deprecations

### DIFF
--- a/addon/metrics-adapters/facebook-pixel.js
+++ b/addon/metrics-adapters/facebook-pixel.js
@@ -64,5 +64,6 @@ export default BaseAdapter.extend({
 
     $('script[src*="fbevents.js"]').remove();
     delete window.fbq;
+    delete window._fbq;
   }
 });

--- a/tests/unit/metrics-adapters/facebook-pixel-test.js
+++ b/tests/unit/metrics-adapters/facebook-pixel-test.js
@@ -53,8 +53,8 @@ function waitForScripts() {
 }
 
 test('#trackEvent calls `fbq.track` with the right arguments', function(assert) {
-  subject.trackEvent({ event: 'Foo', opt1: 'bar', opt2: 'baz' });
-  assert.ok(fbq.calledWith('track', 'Foo', { opt1: 'bar', opt2: 'baz' }), 'it sends the correct arguments and options');
+  subject.trackEvent({ event: 'Search', opt1: 'bar', opt2: 'baz' });
+  assert.ok(fbq.calledWith('track', 'Search', { opt1: 'bar', opt2: 'baz' }), 'it sends the correct arguments and options');
 });
 
 test('#trackPage calls `fbq.track` with the right arguments', function(assert) {

--- a/tests/unit/metrics-adapters/google-analytics-test.js
+++ b/tests/unit/metrics-adapters/google-analytics-test.js
@@ -18,7 +18,7 @@ moduleFor('ember-metrics@metrics-adapter:google-analytics', 'google-analytics ad
 
 test('#init calls ga for any plugins specified', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'ga', () => {
+  const stub = sandbox.stub(window, 'ga').callsFake(() => {
     return true;
   });
   adapter.init();
@@ -27,7 +27,7 @@ test('#init calls ga for any plugins specified', function(assert) {
 
 test('#identify calls ga with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'ga', () => {
+  const stub = sandbox.stub(window, 'ga').callsFake(() => {
     return true;
   });
   adapter.identify({

--- a/tests/unit/metrics-adapters/google-tag-manager-test.js
+++ b/tests/unit/metrics-adapters/google-tag-manager-test.js
@@ -17,7 +17,7 @@ moduleFor('ember-metrics@metrics-adapter:google-tag-manager', 'google-tag-manage
 
 test('#trackEvent returns the correct response shape', function(assert) {
   const adapter = this.subject({ config });
-  sandbox.stub(window, 'dataLayer', {push(){}});
+  sandbox.stub(window, 'dataLayer').value({push(){}});
 
   const result = adapter.trackEvent({
     event: 'click-button',
@@ -39,7 +39,7 @@ test('#trackEvent returns the correct response shape', function(assert) {
 
 test('#trackPage returns the correct response shape', function(assert) {
   const adapter = this.subject({ config });
-  sandbox.stub(window, 'dataLayer', { push(){} });
+  sandbox.stub(window, 'dataLayer').value({ push(){} });
 
   const result = adapter.trackPage({
     url: '/my-overridden-page?id=1',
@@ -62,7 +62,7 @@ test('#trackPage accepts a custom dataLayer name', function(assert) {
     config: customConfig
   });
 
-  sandbox.stub(window, 'customDataLayer', { push(){} });
+  sandbox.stub(window, 'customDataLayer').value({ push(){} });
 
   const result = adapter.trackPage({
     url: '/my-overridden-page?id=1',
@@ -80,7 +80,7 @@ test('#trackPage accepts a custom dataLayer name', function(assert) {
 
 test('#trackPage accepts custom `keyNames` and returns the correct response shape', function(assert) {
   const adapter = this.subject({ config });
-  sandbox.stub(window, 'dataLayer', { push(){} });
+  sandbox.stub(window, 'dataLayer').value({ push(){} });
 
   const result = adapter.trackPage({
     event: 'VirtualPageView',

--- a/tests/unit/metrics-adapters/intercom-test.js
+++ b/tests/unit/metrics-adapters/intercom-test.js
@@ -17,7 +17,7 @@ moduleFor('ember-metrics@metrics-adapter:intercom', 'intercom adapter', {
 
 test('#identify with `distinctId` calls `Intercom()` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'Intercom', () => {
+  const stub = sandbox.stub(window, 'Intercom').callsFake(() => {
     return true;
   });
   adapter.identify({
@@ -33,7 +33,7 @@ test('#identify with `distinctId` calls `Intercom()` with the right arguments', 
 
 test('#identify with `email` calls `Intercom()` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'Intercom', () => {
+  const stub = sandbox.stub(window, 'Intercom').callsFake(() => {
     return true;
   });
   adapter.identify({
@@ -49,7 +49,7 @@ test('#identify with `email` calls `Intercom()` with the right arguments', funct
 
 test('#identify without `distinctId` or `email` throws', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'Intercom', () => {
+  const stub = sandbox.stub(window, 'Intercom').callsFake(() => {
     return true;
   });
   assert.throws(() => {
@@ -62,7 +62,7 @@ test('#identify without `distinctId` or `email` throws', function(assert) {
 
 test('#identify calls `Intercom()` with `boot` on initial call, then `update` on subsequent calls', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'Intercom', () => {
+  const stub = sandbox.stub(window, 'Intercom').callsFake(() => {
     return true;
   });
   adapter.identify({
@@ -81,7 +81,7 @@ test('#identify calls `Intercom()` with `boot` on initial call, then `update` on
 
 test('#trackEvent calls `Intercom()` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'Intercom', () => {
+  const stub = sandbox.stub(window, 'Intercom').callsFake(() => {
     return true;
   });
   adapter.trackEvent({
@@ -98,7 +98,7 @@ test('#trackEvent calls `Intercom()` with the right arguments', function(assert)
 
 test('#trackPage calls `Intercom()` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window, 'Intercom', () => {
+  const stub = sandbox.stub(window, 'Intercom').callsFake(() => {
     return true;
   });
   adapter.trackPage({

--- a/tests/unit/metrics-adapters/mixpanel-test.js
+++ b/tests/unit/metrics-adapters/mixpanel-test.js
@@ -17,10 +17,10 @@ moduleFor('ember-metrics@metrics-adapter:mixpanel', 'mixpanel adapter', {
 
 test('#identify calls `mixpanel.identify` and `mixpanel.people.set` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const identify_stub = sandbox.stub(window.mixpanel, 'identify', () => {
+  const identify_stub = sandbox.stub(window.mixpanel, 'identify').callsFake(() => {
     return true;
   });
-  const people_set_stub = sandbox.stub(window.mixpanel.people, 'set', () => {
+  const people_set_stub = sandbox.stub(window.mixpanel.people, 'set').callsFake(() => {
     return true;
   });
   adapter.identify({
@@ -39,7 +39,7 @@ test('#identify calls `mixpanel.identify` and `mixpanel.people.set` with the rig
 
 test('#trackEvent calls `mixpanel.track` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window.mixpanel, 'track', () => {
+  const stub = sandbox.stub(window.mixpanel, 'track').callsFake(() => {
     return true;
   });
   adapter.trackEvent({
@@ -56,7 +56,7 @@ test('#trackEvent calls `mixpanel.track` with the right arguments', function(ass
 
 test('#trackPage calls `mixpanel.track` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window.mixpanel, 'track', () => {
+  const stub = sandbox.stub(window.mixpanel, 'track').callsFake(() => {
     return true;
   });
   adapter.trackPage({
@@ -72,7 +72,7 @@ test('#trackPage calls `mixpanel.track` with the right arguments', function(asse
 
 test('#alias calls `mixpanel.alias` with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window.mixpanel, 'alias', () => {
+  const stub = sandbox.stub(window.mixpanel, 'alias').callsFake(() => {
     return true;
   });
   adapter.alias({

--- a/tests/unit/metrics-adapters/piwik-test.js
+++ b/tests/unit/metrics-adapters/piwik-test.js
@@ -18,7 +18,7 @@ moduleFor('ember-metrics@metrics-adapter:piwik', 'piwik adapter', {
 
 test('#identify calls piwik with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window._paq, 'push', () => {
+  const stub = sandbox.stub(window._paq, 'push').callsFake(() => {
     return true;
   });
   adapter.identify({
@@ -29,7 +29,7 @@ test('#identify calls piwik with the right arguments', function(assert) {
 
 test('#trackEvent calls piwik with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window._paq, 'push', () => {
+  const stub = sandbox.stub(window._paq, 'push').callsFake(() => {
     return true;
   });
   adapter.trackEvent({
@@ -44,7 +44,7 @@ test('#trackEvent calls piwik with the right arguments', function(assert) {
 
 test('#trackPage calls piwik with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window._paq, 'push', () => {
+  const stub = sandbox.stub(window._paq, 'push').callsFake(() => {
     return true;
   });
   adapter.trackPage({

--- a/tests/unit/metrics-adapters/segment-test.js
+++ b/tests/unit/metrics-adapters/segment-test.js
@@ -17,7 +17,7 @@ moduleFor('ember-metrics@metrics-adapter:segment', 'segment adapter', {
 
 test('#identify calls analytics with the right arguments', function(assert) {
   const adapter = this.subject({ config });
-  const stub = sandbox.stub(window.analytics, 'identify', () => {
+  const stub = sandbox.stub(window.analytics, 'identify').callsFake(() => {
     return true;
   });
   adapter.identify({


### PR DESCRIPTION
* uses new sinon stub syntax
* improves facebook-pixel cleanup
* fixes a warning in facebook-pixel test

After submitting this PR I have removed two commits that were fixing Ember deprecations since ember-metrics is still targeting older versions.