### PR TITLE
Add context to identify calls in the Segment adapter

### DIFF
--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -42,10 +42,12 @@ export default BaseAdapter.extend({
 
   identify(options = {}) {
     const compactedOptions = compact(options);
-    const { distinctId } = compactedOptions;
+    const { distinctId, segmentContext } = compactedOptions;
+    const compactedContext = compact(segmentContext);
     delete compactedOptions.distinctId;
+    delete compactedOptions.segmentContext;
     if(canUseDOM) {
-      window.analytics.identify(distinctId, compactedOptions);
+      window.analytics.identify(distinctId, compactedOptions, compactedContext);
     }
   },
 

--- a/tests/unit/metrics-adapters/segment-test.js
+++ b/tests/unit/metrics-adapters/segment-test.js
@@ -23,7 +23,23 @@ test('#identify calls analytics with the right arguments', function(assert) {
   adapter.identify({
     distinctId: 123
   });
-  assert.ok(stub.calledWith(123), 'it sends the correct arguments');
+  assert.ok(stub.calledWith(123, {}, {}), 'it sends the correct arguments');
+});
+
+test('#identify calls analytics with Segment context', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'identify', () => {
+    return true;
+  });
+  adapter.identify({
+    distinctId: 123,
+    segmentContext: {
+      Intercom: {
+        user_hash: 'abc123'
+      }
+    }
+  });
+  assert.ok(stub.calledWith(123, {}, { Intercom: { user_hash: 'abc123' } }), 'it sends the correct arguments');
 });
 
 test('#trackEvent returns the correct response shape', function(assert) {


### PR DESCRIPTION
This adds the ability to add a context object to the `identify` calls in the Segment adapter. This is particularly important for implementing Intercom's identify verification, [per Segment's documentation](https://segment.com/docs/destinations/intercom/#identity-verification).

Added tests for the `identify` and modified the other `identify` test for greater clarity of what arguments are getting passed to `window.analytics` via the stub.

Happy to add documentation if needed. I didn't see any adapter-specific docs so I was hesitant to add a whole new section.

I know one possible concern is the confusion with `ember-metrics`'s own `context`, but given that this is also a Segment keyword, the best I think we can do to mitigate that API naming conflict is to pass in an explicit `segmentContext`, similar to how `distinctId` is handled in `identify`.