### PR TITLE
Google Tag Manager dataLayer fix

### DIFF
--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -9,6 +9,7 @@ const {
   set,
   $,
   getWithDefault,
+  isBlank,
   String: { capitalize }
 } = Ember;
 const assign = Ember.assign || Ember.merge;
@@ -17,7 +18,8 @@ const {
 } = objectTransforms;
 
 export default BaseAdapter.extend({
-  dataLayer: 'dataLayer',
+  dataLayerProp: 'dataLayer',
+  dataLayer: null,
 
   toStringExtension() {
     return 'GoogleTagManager';
@@ -26,11 +28,11 @@ export default BaseAdapter.extend({
   init() {
     const config = get(this, 'config');
     const { id, envParams, dataLayer } = config;
-    if (dataLayer) {
+    if (!isBlank(dataLayer)) {
       set(this, 'dataLayer', dataLayer);
     }
 
-    const dataLayerProp = get(this, 'dataLayer');
+    const dataLayerProp = get(this, 'dataLayerProp');
     const dataLayerValue = getWithDefault(config, dataLayerProp, []);
     const envParamsString = envParams ? `&${envParams}`: '';
 
@@ -58,7 +60,7 @@ export default BaseAdapter.extend({
   trackEvent(options = {}) {
     const compactedOptions = compact(options);
     const gtmEvent = {'event': compactedOptions['event']};
-    const dataLayerProp = get(this, 'dataLayer');
+    const dataLayerProp = get(this, 'dataLayerProp');
 
     delete compactedOptions['event'];
 
@@ -76,7 +78,7 @@ export default BaseAdapter.extend({
 
   trackPage(options = {}) {
     const compactedOptions = compact(options);
-    const dataLayerProp = get(this, 'dataLayer');
+    const dataLayerProp = get(this, 'dataLayerProp');
     const sendEvent = {
       event: compactedOptions['event'] || 'pageview'
     };
@@ -93,7 +95,7 @@ export default BaseAdapter.extend({
   willDestroy() {
     if (canUseDOM) {
       $('script[src*="gtm.js"]').remove();
-      delete window[get(this, 'dataLayer')];
+      delete window[get(this, 'dataLayerProp')];
     }
   }
 });

--- a/tests/unit/metrics-adapters/google-tag-manager-test.js
+++ b/tests/unit/metrics-adapters/google-tag-manager-test.js
@@ -53,15 +53,15 @@ test('#trackPage returns the correct response shape', function(assert) {
   assert.deepEqual(result, expectedResult, 'it sends the correct response shape');
 });
 
-test('#trackPage accepts a custom dataLayer name', function(assert) {
+test('#trackPage accepts a custom dataLayerProp name', function(assert) {
   const customConfig = config;
-  customConfig['dataLayer'] = 'customDataLayer';
+  customConfig['dataLayerProp'] = 'customDataLayerProp';
 
   const adapter = this.subject({
     config: customConfig
   });
 
-  sandbox.stub(window, 'customDataLayer').value({ push(){} });
+  sandbox.stub(window, 'customDataLayerProp').value({ push(){} });
 
   const result = adapter.trackPage({
     url: '/my-overridden-page?id=1',

--- a/tests/unit/metrics-adapters/google-tag-manager-test.js
+++ b/tests/unit/metrics-adapters/google-tag-manager-test.js
@@ -33,7 +33,6 @@ test('#trackEvent returns the correct response shape', function(assert) {
     'eventLabel': 'nav buttons',
     'eventValue': 4
   };
-
   assert.deepEqual(result, expectedResult, 'it sends the correct response shape');
 });
 
@@ -76,6 +75,26 @@ test('#trackPage accepts a custom dataLayer name', function(assert) {
   };
 
   assert.deepEqual(result, expectedResult, 'it sends the correct response shape');
+});
+
+test('#trackPage accepts a custom dataLayer', function(assert) {
+  const adapter = this.subject({ config });
+  const dataLayer = [{foo: 'bar'}];
+  sandbox.stub(window, 'dataLayer').value(dataLayer);
+
+  const result = adapter.trackPage({
+    url: '/my-overridden-page?id=1',
+    title: 'my overridden page'
+  });
+
+  const expectedResult = {
+    'event': 'pageview',
+    'url': '/my-overridden-page?id=1',
+    'title': 'my overridden page'
+  };
+
+  assert.deepEqual(result, expectedResult, 'it sends the correct response shape');
+  assert.deepEqual(dataLayer, window.dataLayer, 'it sets the default dataLayer');
 });
 
 test('#trackPage accepts custom `keyNames` and returns the correct response shape', function(assert) {


### PR DESCRIPTION
According to the GTM dev guide (https://developers.google.com/tag-manager/devguide) the dataLayer should be set as a global variable and Google will be in charge of retriving such variable with their gtm.js iframe.

Fixes #127 