### PR TITLE
Fixes another Fastboot `TypeError: window.ga is not a function` instance

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -110,7 +110,7 @@ export default BaseAdapter.extend({
 
     const event = assign(sendEvent, compactedOptions);
     for (let key in compactedOptions) {
-      if (compactedOptions.hasOwnProperty(key)) {
+      if (compactedOptions.hasOwnProperty(key) && canUseDOM) {
         window.ga('set', key, compactedOptions[key]);
       }
     }


### PR DESCRIPTION
Wraps one more instance of `window.ga` in a `canUseDOM` condition to prevent Fastboot errors.