### PR TITLE
Segment adapter: Support reset

### DIFF
--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -23,7 +23,7 @@ export default BaseAdapter.extend({
 
     if (canUseDOM) {
       /* eslint-disable */
-      window.analytics=window.analytics||[],window.analytics.methods=["identify","group","track","page","pageview","alias","ready","on","once","off","trackLink","trackForm","trackClick","trackSubmit"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var key=window.analytics.methods[i];window.analytics[key]=window.analytics.factory(key)}window.analytics.load=function(t){if(!document.getElementById("analytics-js")){var a=document.createElement("script");a.type="text/javascript",a.id="analytics-js",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)}},window.analytics.SNIPPET_VERSION="2.0.9";
+      window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
       /* eslint-enable */
       window.analytics.load(segmentKey);
     }
@@ -66,6 +66,12 @@ export default BaseAdapter.extend({
 
     if(canUseDOM) {
       window.analytics.page(page, compactedOptions);
+    }
+  },
+
+  reset() {
+    if(canUseDOM) {
+      window.analytics.reset();
     }
   },
 

--- a/tests/unit/metrics-adapters/segment-test.js
+++ b/tests/unit/metrics-adapters/segment-test.js
@@ -75,3 +75,11 @@ test('#alias returns the correct response shape', function(assert) {
 
   assert.ok(stub.calledWith('foo', 'bar'), 'page called with default arguments');
 });
+
+test('#reset returns the correct response shape', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'reset');
+  adapter.reset();
+
+  assert.ok(stub.calledWith(), 'reset called with no arguments');
+});


### PR DESCRIPTION
I noticed that there was no way of invoking `reset` in the Segment adapter.

https://segment.com/docs/sources/website/analytics.js/#reset-logout