### PR TITLE
Making piwik tests pass consistently

### DIFF
--- a/tests/unit/metrics-adapters/piwik-test.js
+++ b/tests/unit/metrics-adapters/piwik-test.js
@@ -7,7 +7,7 @@ moduleFor('ember-metrics@metrics-adapter:piwik', 'piwik adapter', {
   beforeEach() {
     sandbox = sinon.sandbox.create();
     config = {
-      piwikUrl: "http://my-cool-url.com",
+      piwikUrl: '/assets',
       siteId: 42
     };
   },


### PR DESCRIPTION
While running tests for this project, I was on a network that hijacked DNS. This caused tests loading `http://my-cool-url.com/piwik.js` to fail because it was loading the HTML for the ISP's search portal rather than a failing network request. This led to annoying, generic "Script Error"s in the test runner.

This PR updates the piwik tests to load an empty `piwik.js` asset from the dummy app of the addon, making tests pass consistently, regardless of what type of mischief the ISP may be up to.