### PR TITLE
Cleanup usage of `copy`

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -1,6 +1,5 @@
 import { assign } from '@ember/polyfills';
 import { isPresent } from '@ember/utils';
-import { copy } from '@ember/object/internals';
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import $ from 'jquery';
@@ -17,7 +16,7 @@ export default BaseAdapter.extend({
   },
 
   init() {
-    const config = copy(get(this, 'config'));
+    const config = assign({}, get(this, 'config'));
     const { id, sendHitTask, trace, require } = config;
     let { debug } = config;
 

--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import { assert } from '@ember/debug';
-import { copy } from '@ember/object/internals';
 import { get } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import canUseDOM from '../utils/can-use-dom';
 import { compact } from '../utils/object-transforms';
 import BaseAdapter from './base';
@@ -12,7 +12,7 @@ export default BaseAdapter.extend({
   },
 
   init() {
-    const config = copy(get(this, 'config'));
+    const config = assign({}, get(this, 'config'));
     const segmentKey = config.key;
 
     assert(`[ember-metrics] You must pass a valid \`key\` to the ${this.toString()} adapter`, segmentKey);

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -2,7 +2,6 @@ import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import { assert } from '@ember/debug';
 import { set, get, getWithDefault } from '@ember/object';
-import { copy } from '@ember/object/internals';
 import { A as emberArray, makeArray } from '@ember/array';
 import { dasherize } from '@ember/string';
 import { getOwner } from '@ember/application';
@@ -116,7 +115,7 @@ export default Service.extend({
     const cachedAdapters = get(this, '_adapters');
     const allAdapterNames = keys(cachedAdapters);
     const [selectedAdapterNames, options] = args.length > 1 ? [makeArray(args[0]), args[1]] : [allAdapterNames, args[0]];
-    const context = copy(get(this, 'context'));
+    const context = assign({}, get(this, 'context'));
     const mergedOptions = assign(context, options);
 
     selectedAdapterNames


### PR DESCRIPTION
As it is deprecated.
More info here: https://github.com/emberjs/ember-copy