### PR TITLE
Fix invalid usage of `import/export`

### DIFF
--- a/addon/utils/object-transforms.js
+++ b/addon/utils/object-transforms.js
@@ -45,3 +45,7 @@ export function isPresent(objectInstance) {
 
   return !!keys.length;
 }
+
+export default {
+  compact, without, only, isPresent
+}


### PR DESCRIPTION
The combination of the way object-transforms.js is authored and the way it's consumed within this addon is not actually valid Javascript! Importing the default export from a module *does not* give you all the individual named imports in a handy container.

The code only happens to work because Ember's loader is being lenient and doesn't really follow the ECMA module spec. But it will break under any spec-compliant module loader, including [embroider](https://github.com/embroider-build/embroider).