### PR TITLE
Fix legacy Android webview

### DIFF
--- a/addon/metrics-adapters/intercom.js
+++ b/addon/metrics-adapters/intercom.js
@@ -25,9 +25,9 @@ export default BaseAdapter.extend({
 
     if (canUseDOM) {
       /* eslint-disable */
-      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',{});}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
+      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',{});}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;(function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
       s.src=`https://widget.intercom.io/widget/${appId}`;
-      var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);} l(); }})()
+      var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);})(); }})()
       /* eslint-enable */
     }
   },


### PR DESCRIPTION
Hi, I've found a little issue and here is the fix.
It can be only reproduced in some Android 5 phones using the system webview.

**Problem**:
Some Android phones running `Android 5` aren't unable to update the system webview and they are stucked in versions `<=39`. If you add the `intercom.js` adapter to your app bundle the browser throws a SyntaxError because it can parse the code, the code conflicts with the strict mode.

![error](https://i.ibb.co/K77VkwV/Screenshot-2019-05-06-at-12-55-42.png)

**Solution**:
I've changed a named function (`function l()`) to an anonymous one.