### PR TITLE
Update Segment's loading snippet

### DIFF
--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -17,7 +17,49 @@ export default BaseAdapter.extend({
     assert(`[ember-metrics] You must pass a valid \`key\` to the ${this.toString()} adapter`, segmentKey);
 
     /* eslint-disable */
-    window.analytics=window.analytics||[],window.analytics.methods=["identify","group","track","page","pageview","alias","ready","on","once","off","trackLink","trackForm","trackClick","trackSubmit"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var key=window.analytics.methods[i];window.analytics[key]=window.analytics.factory(key)}window.analytics.load=function(t){if(!document.getElementById("analytics-js")){var a=document.createElement("script");a.type="text/javascript",a.id="analytics-js",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)}},window.analytics.SNIPPET_VERSION="2.0.9";
+    (window.analytics = window.analytics || []),
+      (window.analytics.methods = [
+        "identify",
+        "group",
+        "track",
+        "page",
+        "pageview",
+        "alias",
+        "ready",
+        "on",
+        "once",
+        "off",
+        "trackLink",
+        "trackForm",
+        "trackClick",
+        "trackSubmit",
+      ]),
+      (window.analytics.factory = function (t) {
+        return function () {
+          var a = Array.prototype.slice.call(arguments);
+          return a.unshift(t), window.analytics.push(a), window.analytics;
+        };
+      });
+    for (var i = 0; i < window.analytics.methods.length; i++) {
+      var key = window.analytics.methods[i];
+      window.analytics[key] = window.analytics.factory(key);
+    }
+    (window.analytics.load = function (t) {
+      if (!document.getElementById("analytics-js")) {
+        var a = document.createElement("script");
+        (a.type = "text/javascript"),
+          (a.id = "analytics-js"),
+          (a.async = !0),
+          (a.src =
+            ("https:" === document.location.protocol ? "https://" : "http://") +
+            "cdn.segment.com/analytics.js/v1/" +
+            t +
+            "/analytics.min.js");
+        var n = document.getElementsByTagName("script")[0];
+        n.parentNode.insertBefore(a, n);
+      }
+    }),
+      (window.analytics.SNIPPET_VERSION = "2.0.9");
     /* eslint-enable */
     window.analytics.load(segmentKey);
   },
@@ -61,5 +103,5 @@ export default BaseAdapter.extend({
     removeFromDOM('script[src*="segment.com"]');
 
     delete window.analytics;
-  }
+  },
 });


### PR DESCRIPTION
### Description

With this PR, I propose to upgrade Segment's loading snippet  (and only the snippet, not the library itself).

The currently loading snippet is taken from an old version of Segment's documentation. I took this one from more recent Segment documentation. This small snippet is versioned. The proposed changes upgrade it from `2.0.9` to `4.1.0`.

To ease the review, I have prettyfied the snippet in a first commit. So that you can review - if you'd like - the snippet itself by comparing the first and the second commit.

Note that I have been using it in production for roughly two years (on a fork that I'm trying to remove 😄).

### Why

The main change to this snippet is that Segment library will support two new methods: `reset` and `debug`.

It loads the same library than before from `http://cdn.segment.com/analytics.js/v1/${segmentKey}/analytics.min.js`.