### PR TITLE
Modernize the metrics-adapter test blueprint

### DIFF
--- a/blueprints/metrics-adapter-test/files/tests/unit/metrics-adapters/__test__.js
+++ b/blueprints/metrics-adapter-test/files/tests/unit/metrics-adapters/__test__.js
@@ -1,12 +1,16 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('metrics-adapter:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
-});
+module('<%= friendlyTestDescription %>', function(hooks) {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  let adapter = this.subject();
-  assert.ok(adapter);
+  // TODO: Replace this with your real tests.
+  test('it exists', function(assert) {
+    let adapter = this.owner.factoryFor('metrics-adapter:<%= dasherizedModuleName %>').create({
+      config: {
+        // TODO: Add adapter config
+      },
+    });
+    assert.ok(adapter);
+  });
 });

--- a/blueprints/metrics-adapter-test/index.js
+++ b/blueprints/metrics-adapter-test/index.js
@@ -1,10 +1,14 @@
 /* eslint-env node */
 
 module.exports = {
-  description: 'Generates an metrics-adapter unit test',
+  description: 'Generates a metrics-adapter unit test',
   locals: function (options) {
     return {
-      friendlyTestDescription: options.entity.name + ' adapter',
+      friendlyTestDescription: [
+        'Unit',
+        'MetricsAdapter',
+        options.entity.name,
+      ].join(' | '),
     };
   },
 };


### PR DESCRIPTION
This modernizes the metrics-adapter test blueprint and makes it consistent with the service-test blueprint of ember-source.

Closes #317 