### PR TITLE
Indicate EmberObject Utilization is Deprecated

### DIFF
--- a/addon/metrics-adapters/base.js
+++ b/addon/metrics-adapters/base.js
@@ -1,5 +1,5 @@
 import emberObject from '@ember/object';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 import { typeOf } from '@ember/utils';
 import { setOwner } from '@ember/application';
@@ -31,6 +31,36 @@ export default class BaseAdapter extends emberObject {
     assert(
       `[ember-metrics] ${this.toString()} must implement the willDestroy hook!`
     );
+  }
+
+  get() {
+    deprecate(
+      'Metrics Adapters must not use EmberObject methods as they will be implemented as native classes in the next major release',
+      false,
+      {
+        id: 'ember-metrics-issue-287',
+        for: 'ember-metrics',
+        url: 'https://github.com/adopted-ember-addons/ember-metrics/issues/287',
+        since: '1.4.0',
+        until: '2.0.0',
+      }
+    );
+    super.get(...arguments);
+  }
+
+  set() {
+    deprecate(
+      'Metrics Adapters must not use EmberObject methods as they will be implemented as native classes in the next major release',
+      false,
+      {
+        id: 'ember-metrics.issue-287',
+        for: 'ember-metrics',
+        url: 'https://github.com/adopted-ember-addons/ember-metrics/issues/287',
+        since: '1.4.0',
+        until: '2.0.0',
+      }
+    );
+    super.set(...arguments);
   }
 
   toString() {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",
     "@embroider/test-setup": "^0.45.0",
+    "@glimmer/tracking": "^1.0.4",
     "@types/ember-qunit": "^3.4.14",
     "@types/ember-resolver": "^5.0.10",
     "@types/ember__application": "^3.16.3",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-
 import { inject as service } from '@ember/service';
 
 export default class ApplicationController extends Controller {

--- a/tests/dummy/app/metrics-adapters/local-dummy-adapter.js
+++ b/tests/dummy/app/metrics-adapters/local-dummy-adapter.js
@@ -1,10 +1,10 @@
 import BaseAdapter from 'ember-metrics/metrics-adapters/base';
-import { inject } from '@ember/service';
+import { inject as service } from '@ember/service';
 
 export default class LocalDummyAdapter extends BaseAdapter {
   static supportsFastBoot = true;
 
-  @inject application;
+  @service application;
 
   toStringExtension() {
     return 'LocalDummy';
@@ -17,7 +17,7 @@ export default class LocalDummyAdapter extends BaseAdapter {
 
   trackEvent({ controller }) {
     if (controller) {
-      controller.set('foo', 'bar');
+      controller.foo = 'bar';
     }
   }
 

--- a/tests/dummy/app/services/application.js
+++ b/tests/dummy/app/services/application.js
@@ -1,1 +1,0 @@
-export { default } from '@ember/service';

--- a/tests/dummy/app/services/application.ts
+++ b/tests/dummy/app/services/application.ts
@@ -1,0 +1,6 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class ApplicationService extends Service {
+  @tracked foo: string | null = null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,6 +1192,11 @@
     "@glimmer/interfaces" "^0.42.2"
     "@glimmer/vm" "^0.42.2"
 
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
 "@glimmer/interfaces@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.2.tgz#9cf8d6f8f5eee6bfcfa36919ca68ae716e1f78db"
@@ -1241,10 +1246,23 @@
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.8"
 
+"@glimmer/tracking@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.4.tgz#f1bc1412fe5e2236d0f8d502994a8f88af1bbb21"
+  integrity sha512-F+oT8I55ba2puSGIzInmVrv/8QA2PcK1VD+GWgFMhF6WC97D+uZX7BFg+a3s/2N4FVBq5KHE+QxZzgazM151Yw==
+  dependencies:
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/validator" "^0.44.0"
+
 "@glimmer/util@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
   integrity sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==
+
+"@glimmer/validator@^0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
+  integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
 "@glimmer/vm-babel-plugins@0.80.0":
   version "0.80.0"


### PR DESCRIPTION
This attempt is fairly naive, but hopefully it catches the majority of
uses in homespun adapters.