### PR TITLE
feat: add plausible adapter

### DIFF
--- a/addon/metrics-adapters/plausible.js
+++ b/addon/metrics-adapters/plausible.js
@@ -1,0 +1,58 @@
+import { assert } from '@ember/debug';
+import removeFromDOM from 'ember-metrics/-private/utils/remove-from-dom';
+import BaseAdapter from './base';
+
+export default class Plausible extends BaseAdapter {
+  toStringExtension() {
+    return Plausible.name;
+  }
+
+  install() {
+    const { siteId, scriptUrl } = this.config;
+    assert(
+      `[ember-metrics] You must pass a \`scriptUrl\` and a \`siteId\` to the ${this.toString()} adapter`,
+      scriptUrl && siteId
+    );
+    this._injectScript(scriptUrl, siteId);
+  }
+
+  // prettier-ignore
+  _injectScript(scriptUrl, siteId) {
+    window.plausible =
+      window.plausible ||
+      function (...args) {
+        (window.plausible.q = window.plausible.q || []).push(args);
+      };
+
+      const scriptElement = document.createElement('script');
+      const firstScriptElement = document.getElementsByTagName('script')[0];
+      scriptElement.type = 'text/javascript';
+      scriptElement.defer = true;
+      scriptElement.async = true;
+      scriptElement.src = scriptUrl;
+      scriptElement.setAttribute('data-domain', siteId);
+      firstScriptElement.parentNode.insertBefore(scriptElement, firstScriptElement);
+  }
+
+  identify() {}
+
+  /**
+   * Custom events allow you to measure button clicks, form completions...
+   *
+   * @param {Object} params
+   * @param {string} params.eventName - must not contain spaces, examples: verify-this or That+Completion
+   * @param {Objects} params.props - event metadatas, must not contain any personally identifiable information
+   */
+  trackEvent({ eventName, plausibleAttributes = {}, ...props }) {
+    window.plausible(eventName, { ...plausibleAttributes, props });
+  }
+
+  trackPage({ plausibleAttributes = {}, ...props }) {
+    window.plausible('pageview', { ...plausibleAttributes, props });
+  }
+
+  uninstall() {
+    removeFromDOM('script[src*="plausible"]');
+    delete window.plausible;
+  }
+}

--- a/app/metrics-adapters/plausible.js
+++ b/app/metrics-adapters/plausible.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/plausible';

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "facebook pixel",
     "amplitude",
     "azure application insights",
-    "pendo"
+    "pendo",
+    "plausible"
   ],
   "homepage": "https://github.com/adopted-ember-addons/ember-metrics",
   "bugs": "https://github.com/adopted-ember-addons/ember-metrics/issues",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -30,6 +30,7 @@ module.exports = function (environment) {
         'pendo',
         'matomo-tag-manager',
         'hotjar',
+        'plausible',
       ],
     },
 

--- a/tests/unit/metrics-adapters/plausible-test.js
+++ b/tests/unit/metrics-adapters/plausible-test.js
@@ -1,0 +1,93 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Plausible from 'ember-metrics/metrics-adapters/plausible';
+
+module('plausible adapter', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.config = {
+      scriptUrl: 'https://plausible.io/js/script.manual.js',
+      siteId: 'my.site.io',
+    };
+
+    this.adapter = new Plausible(this.config);
+    this.adapter.install();
+  });
+
+  hooks.afterEach(function () {
+    this.adapter.uninstall();
+  });
+
+  test('#install installs container correctly', function (assert) {
+    const script = document.querySelector('script[src*="plausible"]');
+    console.log({ script });
+    assert.strictEqual(
+      script.getAttribute('src'),
+      'https://plausible.io/js/script.manual.js'
+    );
+    assert.strictEqual(script.getAttribute('data-domain'), 'my.site.io');
+  });
+
+  test('#trackEvent calls Plausible with the right arguments', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackEvent({
+      eventName: 'click menu',
+      action: 'click',
+      category: 'navigation',
+      value: 'profile',
+    });
+    assert.spy(stub).calledWith(
+      [
+        'click menu',
+        {
+          props: {
+            category: 'navigation',
+            action: 'click',
+            value: 'profile',
+          },
+        },
+      ],
+      'it sends the correct arguments'
+    );
+  });
+
+  test('#trackPage calls Plausible with the right arguments', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackPage({
+      page: 'page',
+    });
+
+    assert
+      .spy(stub)
+      .calledWith(
+        ['pageview', { props: { page: 'page' } }],
+        'it sends the correct arguments'
+      );
+  });
+
+  test('#trackPage calls Plausible with the overriden plausible props', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackPage({
+      plausibleAttributes: { u: '/page/_ID_/test?id=1' },
+      page: 'page',
+    });
+
+    assert
+      .spy(stub)
+      .calledWith(
+        ['pageview', { u: '/page/_ID_/test?id=1', props: { page: 'page' } }],
+        'it sends the correct arguments'
+      );
+  });
+});


### PR DESCRIPTION
Add [Plausible](https://plausible.io/) adapter
It took me some time to figure out that I need to add plausible to `test/dummy/config/environment.js` before tests run correctly :)

We give the possibility to pass a `plausibleAttributes` to trackPage in order to allow users to redact their url 
https://plausible.io/docs/custom-locations#redacting-identifiers-from-urls